### PR TITLE
fix nouns builder hyperlink for builder daos

### DIFF
--- a/src/fidgets/community/nouns-dao/NounishGovernance.tsx
+++ b/src/fidgets/community/nouns-dao/NounishGovernance.tsx
@@ -176,7 +176,7 @@ export const NounishGovernance: React.FC<
           loading={listLoading}
           isBuilderSubgraph={isBuilderSubgraph}
           title={isBuilderSubgraph ? selectedDao.name : "Nouns DAO"}
-          daoIcon={selectedDao.icon || "images/nounspace_logo.png"}
+          daoIcon={selectedDao.icon || "/images/nouns_yellow_logo.jpg"}
         />
       )}
     </CardContent>

--- a/src/fidgets/community/nouns-dao/components/BuilderProposalDetailView.tsx
+++ b/src/fidgets/community/nouns-dao/components/BuilderProposalDetailView.tsx
@@ -154,7 +154,6 @@ export const BuilderProposalDetailView = ({
     : new Date();
   const formattedEndDate = moment(endDate).format("MMM D, YYYY");
   const formattedEndTime = moment(endDate).format("h:mm A");
-
   return (
     <div className="flex flex-col size-full">
       <div className="flex justify-between pb-3">
@@ -167,7 +166,7 @@ export const BuilderProposalDetailView = ({
           <FaArrowLeft />
         </Button>
         <a
-          href={`https://www.nouns.camp/proposals/${proposal.id}`}
+          href={`https://www.nouns.build/dao/base/${proposal.dao.tokenAddress}/vote/${proposal.proposalNumber}`}
           target="_blank"
           rel="noreferrer"
         >


### PR DESCRIPTION
Now it points to the proposal on nouns builder for builder daos, nouns gov still points to nouns.camp