### PR TITLE
Fix Cast button color in modal

### DIFF
--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -635,6 +635,7 @@ const CreateCast: React.FC<CreateCastProps> = ({
           <div className="flex flex-row pt-0 justify-end">
             <Button
               size="lg"
+              variant="primary"
               type="submit"
               className="line-clamp-1 min-w-40 max-w-xs truncate"
               disabled={isPublishing || isLoadingSigner}


### PR DESCRIPTION
## Notes
- `npm run lint` fails: `sh: 1: next: not found`
- `npm run check-types` fails: missing type definitions

## Summary
- use `variant="primary"` for the Cast button in the modal so its color matches the nav

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definition file)*