### PR TITLE
Restore fc:frame meta tag

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,6 @@ import "@/styles/globals.css";
 import Providers from "@/common/providers";
 import Sidebar from "@/common/components/organisms/Sidebar";
 import { SpeedInsights } from "@vercel/speed-insights/next";
-import Head from "next/head";
 import { defaultFrame } from "@/common/lib/frames/metadata";
 
 export const metadata = {
@@ -57,9 +56,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <Head>
+      <head>
         <meta name="fc:frame" content={JSON.stringify(defaultFrame)} />
-      </Head>
+      </head>
       <body>
         <SpeedInsights />
         <Providers>{sidebarLayout(children)}</Providers>


### PR DESCRIPTION
## Summary
- add `<meta name="fc:frame" content={JSON.stringify(defaultFrame)} />` to `layout.tsx`
- keep metadata export

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*