### PR TITLE
Update EditorPanel with mobile settings

### DIFF
--- a/src/common/components/molecules/IconSelector.tsx
+++ b/src/common/components/molecules/IconSelector.tsx
@@ -1,0 +1,148 @@
+import React, { useEffect, useState, useRef } from 'react'
+import { SearchIcon, UploadIcon } from 'lucide-react'
+import { createPortal } from 'react-dom'
+
+interface IconSelectorProps {
+  onSelectIcon: (icon: string) => void
+  triggerRef: React.RefObject<HTMLElement>
+  onClose: () => void
+}
+
+export function IconSelector({ onSelectIcon, triggerRef, onClose }: IconSelectorProps) {
+  const [searchTerm, setSearchTerm] = useState('')
+  const [activeTab, setActiveTab] = useState<'library' | 'custom'>('library')
+  const [position, setPosition] = useState({ top: 0, left: 0, width: 0 })
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  const iconLibrary = [
+    'RssIcon',
+    'VoteIcon',
+    'ImageIcon',
+    'HomeIcon',
+    'GiftIcon',
+    'UserIcon',
+    'SettingsIcon',
+    'BellIcon',
+    'CalendarIcon',
+    'MessageIcon',
+    'FileIcon',
+    'FolderIcon',
+    'StarIcon',
+    'HeartIcon',
+    'ShareIcon',
+  ]
+  const filteredIcons = iconLibrary.filter((icon) =>
+    icon.toLowerCase().includes(searchTerm.toLowerCase()),
+  )
+
+  useEffect(() => {
+    if (triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect()
+      const windowHeight = window.innerHeight
+      const windowWidth = window.innerWidth
+      const dropdownWidth = Math.max(320, rect.width)
+      const dropdownHeight = 400
+      let top = rect.bottom + window.scrollY + 4
+      let left = rect.left + window.scrollX
+      if (rect.bottom + dropdownHeight > windowHeight) {
+        top = rect.top + window.scrollY - dropdownHeight - 4
+      }
+      if (left + dropdownWidth > windowWidth) {
+        left = windowWidth - dropdownWidth - 16
+      }
+      setPosition({ top, left, width: dropdownWidth })
+    }
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node) &&
+        !triggerRef.current?.contains(event.target as Node)
+      ) {
+        onClose()
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [triggerRef, onClose])
+
+  const handleIconSelect = (icon: string) => {
+    onSelectIcon(icon)
+    onClose()
+  }
+
+  return createPortal(
+    <div
+      ref={dropdownRef}
+      className="fixed bg-white border border-gray-200 rounded-md shadow-lg z-50 max-h-80 overflow-auto"
+      style={{ top: `${position.top}px`, left: `${position.left}px`, width: `${position.width}px` }}
+    >
+      <div className="p-3 border-b border-gray-200">
+        <div className="relative">
+          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <SearchIcon className="h-4 w-4 text-gray-400" />
+          </div>
+          <input
+            type="text"
+            placeholder="Search icons..."
+            className="pl-10 w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="flex border-b border-gray-200">
+        <button
+          className={`flex-1 px-4 py-2 text-sm font-medium ${activeTab === 'library' ? 'text-blue-600 border-b-2 border-blue-600' : 'text-gray-500'}`}
+          onClick={() => setActiveTab('library')}
+        >
+          Icon Library
+        </button>
+        <button
+          className={`flex-1 px-4 py-2 text-sm font-medium ${activeTab === 'custom' ? 'text-blue-600 border-b-2 border-blue-600' : 'text-gray-500'}`}
+          onClick={() => setActiveTab('custom')}
+        >
+          Custom Upload
+        </button>
+      </div>
+      {activeTab === 'library' ? (
+        <div className="p-3 grid grid-cols-5 gap-2">
+          {filteredIcons.length > 0 ? (
+            filteredIcons.map((icon) => (
+              <button
+                key={icon}
+                onClick={() => handleIconSelect(icon)}
+                className="flex flex-col items-center justify-center p-2 hover:bg-gray-100 rounded-md"
+              >
+                <div className="w-8 h-8 bg-gray-100 rounded-md flex items-center justify-center mb-1">
+                  {icon.charAt(0)}
+                </div>
+                <span className="text-xs text-gray-600 truncate w-full text-center">
+                  {icon}
+                </span>
+              </button>
+            ))
+          ) : (
+            <div className="col-span-5 py-4 text-center text-gray-500">No icons found</div>
+          )}
+        </div>
+      ) : (
+        <div className="p-6 flex flex-col items-center justify-center">
+          <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mb-4">
+            <UploadIcon className="h-8 w-8 text-gray-400" />
+          </div>
+          <p className="text-sm text-gray-600 mb-4 text-center">
+            Upload a custom icon (SVG, PNG, or JPG)
+          </p>
+          <label className="cursor-pointer bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded-md">
+            <span>Upload Icon</span>
+            <input type="file" className="hidden" accept="image/*" />
+          </label>
+        </div>
+      )}
+    </div>,
+    document.body,
+  )
+}
+
+export default IconSelector

--- a/src/common/components/molecules/MiniAppSettings.tsx
+++ b/src/common/components/molecules/MiniAppSettings.tsx
@@ -1,0 +1,127 @@
+import React, { useState, useRef } from 'react'
+import { IconSelector } from './IconSelector'
+import { EyeIcon, EyeOffIcon, GripVerticalIcon } from 'lucide-react'
+
+export interface MiniApp {
+  id: string | number
+  name: string
+  mobileDisplayName: string
+  context?: string
+  order: number
+  icon: string
+  displayOnMobile: boolean
+}
+
+interface MiniAppSettingsProps {
+  miniApp: MiniApp
+  onUpdateMiniApp: (app: MiniApp) => void
+}
+
+export function MiniAppSettings({ miniApp, onUpdateMiniApp }: MiniAppSettingsProps) {
+  const [isIconSelectorOpen, setIsIconSelectorOpen] = useState(false)
+  const iconButtonRef = useRef<HTMLButtonElement>(null)
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onUpdateMiniApp({ ...miniApp, mobileDisplayName: e.target.value })
+  }
+
+  const handleIconSelect = (iconName: string) => {
+    onUpdateMiniApp({ ...miniApp, icon: iconName })
+    setIsIconSelectorOpen(false)
+  }
+
+  const toggleVisibility = () => {
+    onUpdateMiniApp({ ...miniApp, displayOnMobile: !miniApp.displayOnMobile })
+  }
+
+  const getIconComponent = (iconName: string) => {
+    const IconMap: Record<string, React.ReactNode> = {
+      RssIcon: (
+        <div className="w-6 h-6 bg-blue-100 text-blue-600 flex items-center justify-center rounded">
+          RSS
+        </div>
+      ),
+      VoteIcon: (
+        <div className="w-6 h-6 bg-purple-100 text-purple-600 flex items-center justify-center rounded">
+          V
+        </div>
+      ),
+      ImageIcon: (
+        <div className="w-6 h-6 bg-green-100 text-green-600 flex items-center justify-center rounded">
+          I
+        </div>
+      ),
+      HomeIcon: (
+        <div className="w-6 h-6 bg-yellow-100 text-yellow-600 flex items-center justify-center rounded">
+          H
+        </div>
+      ),
+      GiftIcon: (
+        <div className="w-6 h-6 bg-red-100 text-red-600 flex items-center justify-center rounded">
+          G
+        </div>
+      ),
+    }
+    return (
+      IconMap[iconName] || (
+        <div className="w-6 h-6 bg-gray-100 flex items-center justify-center rounded">?</div>
+      )
+    );
+  }
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg">
+      <div className="p-3">
+        <div className="flex items-center gap-2 mb-3">
+          <div className="cursor-move p-1 hover:bg-gray-100 rounded shrink-0" title="Drag to reorder">
+            <GripVerticalIcon className="h-4 w-4 text-gray-400" />
+          </div>
+          <div className="text-sm text-gray-500 truncate flex-1">
+            {miniApp.context}
+          </div>
+          <button
+            onClick={toggleVisibility}
+            className={`p-1.5 rounded-md transition-colors shrink-0 ${miniApp.displayOnMobile ? 'bg-blue-100 text-blue-600 hover:bg-blue-200' : 'bg-gray-100 text-gray-400 hover:bg-gray-200'}`}
+          >
+            {miniApp.displayOnMobile ? (
+              <EyeIcon className="h-4 w-4" />
+            ) : (
+              <EyeOffIcon className="h-4 w-4" />
+            )}
+          </button>
+        </div>
+        <div className="flex gap-2">
+          <div className="flex-1">
+            <label className="block text-xs text-gray-500 mb-1">Name</label>
+            <input
+              type="text"
+              value={miniApp.mobileDisplayName}
+              onChange={handleNameChange}
+              className="w-full h-10 px-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Display name"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">Icon</label>
+            <button
+              type="button"
+              ref={iconButtonRef}
+              onClick={() => setIsIconSelectorOpen(!isIconSelectorOpen)}
+              className="h-10 w-10 flex items-center justify-center border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {getIconComponent(miniApp.icon)}
+            </button>
+            {isIconSelectorOpen && (
+              <IconSelector
+                onSelectIcon={handleIconSelect}
+                triggerRef={iconButtonRef}
+                onClose={() => setIsIconSelectorOpen(false)}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default MiniAppSettings

--- a/src/common/components/organisms/EditorPanel.tsx
+++ b/src/common/components/organisms/EditorPanel.tsx
@@ -136,12 +136,14 @@ export const EditorPanel: React.FC<EditorPanelProps> = ({
                   setIsPickingFidget={setIsPickingFidget}
                 />
               ) : (
-                <ThemeSettingsEditor
-                  theme={theme}
-                  saveTheme={saveTheme}
-                  saveExitEditMode={saveExitEditMode}
-                  cancelExitEditMode={cancelExitEditMode}
-                />
+              <ThemeSettingsEditor
+                theme={theme}
+                saveTheme={saveTheme}
+                saveExitEditMode={saveExitEditMode}
+                cancelExitEditMode={cancelExitEditMode}
+                fidgetInstanceDatums={fidgetInstanceDatums}
+                saveFidgetInstanceDatums={saveFidgetInstanceDatums}
+              />
               )}
             </>
           )}

--- a/src/common/components/organisms/MobileSettings.tsx
+++ b/src/common/components/organisms/MobileSettings.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react'
+import { Reorder } from 'framer-motion'
+import MiniAppSettings, { MiniApp } from '../molecules/MiniAppSettings'
+
+interface MobileSettingsProps {
+  miniApps: MiniApp[]
+  onUpdateMiniApp: (app: MiniApp) => void
+}
+
+export function MobileSettings({ miniApps, onUpdateMiniApp }: MobileSettingsProps) {
+  const [items, setItems] = useState<MiniApp[]>([])
+
+  useEffect(() => {
+    const sorted = [...miniApps].sort((a, b) => a.order - b.order)
+    setItems(sorted)
+  }, [miniApps])
+
+  const handleReorder = (newOrder: MiniApp[]) => {
+    setItems(newOrder)
+    newOrder.forEach((item, index) => {
+      onUpdateMiniApp({ ...item, order: index + 1 })
+    })
+  }
+
+  return (
+    <div className="p-4">
+      <h2 className="text-lg font-semibold mb-2">Edit</h2>
+      <div className="mb-6">
+        <h3 className="text-md font-medium mb-1">Mobile Settings</h3>
+        <p className="text-sm text-gray-500 mb-4">Configure how fidgets appear on mobile</p>
+      </div>
+      <Reorder.Group axis="y" values={items} onReorder={handleReorder} className="space-y-3">
+        {items.map((miniApp) => (
+          <Reorder.Item key={miniApp.id} value={miniApp} className="cursor-default">
+            <MiniAppSettings miniApp={miniApp} onUpdateMiniApp={onUpdateMiniApp} />
+          </Reorder.Item>
+        ))}
+      </Reorder.Group>
+    </div>
+  )
+}
+
+export default MobileSettings

--- a/src/common/components/organisms/MobileSettings.tsx
+++ b/src/common/components/organisms/MobileSettings.tsx
@@ -5,9 +5,10 @@ import MiniAppSettings, { MiniApp } from '../molecules/MiniAppSettings'
 interface MobileSettingsProps {
   miniApps: MiniApp[]
   onUpdateMiniApp: (app: MiniApp) => void
+  onReorder?: (apps: MiniApp[]) => void
 }
 
-export function MobileSettings({ miniApps, onUpdateMiniApp }: MobileSettingsProps) {
+export function MobileSettings({ miniApps, onUpdateMiniApp, onReorder }: MobileSettingsProps) {
   const [items, setItems] = useState<MiniApp[]>([])
 
   useEffect(() => {
@@ -20,6 +21,9 @@ export function MobileSettings({ miniApps, onUpdateMiniApp }: MobileSettingsProp
     newOrder.forEach((item, index) => {
       onUpdateMiniApp({ ...item, order: index + 1 })
     })
+    if (onReorder) {
+      onReorder(newOrder)
+    }
   }
 
   return (

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -112,6 +112,17 @@ export function ThemeSettingsEditor({
     saveFidgetInstanceDatums(newDatums);
   };
 
+  const handleReorderMiniApps = (apps: MiniApp[]) => {
+    const newDatums: { [key: string]: FidgetInstanceData } = {};
+    apps.forEach(app => {
+      const datum = fidgetInstanceDatums[app.id];
+      if (datum) {
+        newDatums[app.id] = datum;
+      }
+    });
+    saveFidgetInstanceDatums(newDatums);
+  };
+
   function themePropSetter<_T extends string>(property: string): (value: string) => void {
     return (value: string): void => {
       const newTheme = {
@@ -362,6 +373,7 @@ export function ThemeSettingsEditor({
                   <MobileSettings
                     miniApps={miniApps}
                     onUpdateMiniApp={handleUpdateMiniApp}
+                    onReorder={handleReorderMiniApps}
                   />
                 </TabsContent>
               </Tabs>

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -23,6 +23,7 @@ import { VideoSelector } from "@/common/components/molecules/VideoSelector";
 import { useAppStore } from "@/common/data/stores/app";
 import { useToastStore } from "@/common/data/stores/toastStore";
 import { Color, FontFamily, ThemeSettings } from "@/common/lib/theme";
+import { FidgetInstanceData } from "@/common/fidgets";
 import { ThemeCard } from "@/common/lib/theme/ThemeCard";
 import DEFAULT_THEME from "@/common/lib/theme/defaultTheme";
 import { FONT_FAMILY_OPTIONS_BY_NAME } from "@/common/lib/theme/fonts";
@@ -39,19 +40,24 @@ import { SPACE_CONTRACT_ADDR } from "@/constants/spaceToken";
 import { THEMES } from "@/constants/themes";
 import { SparklesIcon } from "@heroicons/react/24/solid";
 import { usePrivy } from "@privy-io/react-auth";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useMemo } from "react";
 import { FaInfoCircle } from "react-icons/fa";
 import { FaFloppyDisk, FaTriangleExclamation, FaX } from "react-icons/fa6";
 import { MdMenuBook } from "react-icons/md";
 import { Address, formatUnits, zeroAddress } from "viem";
 import { base } from "viem/chains";
 import { useBalance } from "wagmi";
+import { CompleteFidgets } from "@/fidgets";
+import MobileSettings from "@/common/components/organisms/MobileSettings";
+import { MiniApp } from "@/common/components/molecules/MiniAppSettings";
 
 export type ThemeSettingsEditorArgs = {
   theme: ThemeSettings;
   saveTheme: (newTheme: ThemeSettings) => void;
   saveExitEditMode: () => void;
   cancelExitEditMode: () => void;
+  fidgetInstanceDatums: { [key: string]: FidgetInstanceData };
+  saveFidgetInstanceDatums: (datums: { [key: string]: FidgetInstanceData }) => Promise<void>;
 };
 
 export function ThemeSettingsEditor({
@@ -59,10 +65,52 @@ export function ThemeSettingsEditor({
   saveTheme,
   saveExitEditMode,
   cancelExitEditMode,
+  fidgetInstanceDatums,
+  saveFidgetInstanceDatums,
 }: ThemeSettingsEditorArgs) {
   const [showConfirmCancel, setShowConfirmCancel] = useState(false);
   const [activeTheme, setActiveTheme] = useState(theme.id);
-  const [tabValue, setTabValue] = useState("fonts");
+  const [tabValue, setTabValue] = useState("space");
+
+  const miniApps = useMemo<MiniApp[]>(() => {
+    return Object.values(fidgetInstanceDatums).map((d, i) => {
+      const props = CompleteFidgets[d.fidgetType]?.properties;
+      return {
+        id: d.id,
+        name: d.fidgetType,
+        mobileDisplayName:
+          (d.config.settings.customMobileDisplayName as string) ||
+          props?.mobileFidgetName ||
+          props?.fidgetName,
+        context: props?.fidgetName,
+        order: (d.config.settings.mobileOrder as number) || i + 1,
+        icon: (d.config.settings.mobileIconName as string) || 'HomeIcon',
+        displayOnMobile: d.config.settings.showOnMobile !== false,
+      };
+    });
+  }, [fidgetInstanceDatums]);
+
+  const handleUpdateMiniApp = (app: MiniApp) => {
+    const datum = fidgetInstanceDatums[app.id];
+    if (!datum) return;
+    const newDatums = {
+      ...fidgetInstanceDatums,
+      [app.id]: {
+        ...datum,
+        config: {
+          ...datum.config,
+          settings: {
+            ...datum.config.settings,
+            customMobileDisplayName: app.mobileDisplayName,
+            mobileIconName: app.icon,
+            showOnMobile: app.displayOnMobile,
+            mobileOrder: app.order,
+          },
+        },
+      },
+    };
+    saveFidgetInstanceDatums(newDatums);
+  };
 
   function themePropSetter<_T extends string>(property: string): (value: string) => void {
     return (value: string): void => {
@@ -181,18 +229,18 @@ export function ThemeSettingsEditor({
               <Tabs value={tabValue} onValueChange={setTabValue}>
                 {/* controlled Tabs */}
                 <TabsList className={tabListClasses}>
-                  <TabsTrigger value="style" className={tabTriggerClasses}>
-                    Style
+                  <TabsTrigger value="space" className={tabTriggerClasses}>
+                    Space
                   </TabsTrigger>
-                  <TabsTrigger value="fonts" className={tabTriggerClasses}>
-                    Fonts
+                  <TabsTrigger value="fidgets" className={tabTriggerClasses}>
+                    Fidgets
                   </TabsTrigger>
-                  <TabsTrigger value="code" className={tabTriggerClasses}>
-                    Code
+                  <TabsTrigger value="mobile" className={tabTriggerClasses}>
+                    Mobile
                   </TabsTrigger>
                 </TabsList>
-                {/* Fonts */}
-                <TabsContent value="fonts" className={tabContentClasses}>
+                {/* Space */}
+                <TabsContent value="space" className={tabContentClasses}>
                   <div className="flex flex-col gap-1">
                     <div className="flex flex-row gap-1">
                       <h4 className="text-sm">Headings</h4>
@@ -235,14 +283,11 @@ export function ThemeSettingsEditor({
                       />
                     </div>
                   </div>
-                </TabsContent>
-                {/* Style */}
-                <TabsContent value="style" className={tabContentClasses}>
-                  <div className="flex flex-col gap-1">
+                  <div className="flex flex-col gap-1 mt-4">
                     <h4 className="text-sm font-bold my-2">Space Settings</h4>
                     <div className="flex flex-row gap-1">
                       <h4 className="text-sm">Background color</h4>
-                      <ThemeSettingsTooltip text="Set a solid background or gradient color. You can also add custom backgrounds with HTML/CSS on the Code tab." />
+                      <ThemeSettingsTooltip text="Set a solid background or gradient color. You can also add custom backgrounds with HTML/CSS on the Generate section." />
                     </div>
                     <ColorSelector
                       className="rounded-full overflow-hidden w-6 h-6 shrink-0"
@@ -251,6 +296,13 @@ export function ThemeSettingsEditor({
                       onChange={themePropSetter<Color>("background")}
                     />
                   </div>
+                  <BackgroundGenerator
+                    backgroundHTML={backgroundHTML}
+                    onChange={themePropSetter<string>("backgroundHTML")}
+                  />
+                </TabsContent>
+                {/* Fidgets */}
+                <TabsContent value="fidgets" className={tabContentClasses}>
                   <div className="flex flex-col gap-1">
                     <h4 className="text-sm font-bold my-2">Fidget Settings</h4>
                     <div className="flex flex-col gap-1">
@@ -305,11 +357,11 @@ export function ThemeSettingsEditor({
                     </div>
                   </div>
                 </TabsContent>
-                {/* Code */}
-                <TabsContent value="code" className={tabContentClasses}>
-                  <BackgroundGenerator
-                    backgroundHTML={backgroundHTML}
-                    onChange={themePropSetter<string>("backgroundHTML")}
+                {/* Mobile */}
+                <TabsContent value="mobile" className={tabContentClasses}>
+                  <MobileSettings
+                    miniApps={miniApps}
+                    onUpdateMiniApp={handleUpdateMiniApp}
                   />
                 </TabsContent>
               </Tabs>
@@ -329,19 +381,6 @@ export function ThemeSettingsEditor({
         </div>
 
         <div className="flex flex-col gap-2">
-          {tabValue === "fonts" && (
-            <div
-              className="flex gap-1 items-center border-2 border-orange-600 text-orange-600 bg-orange-100 rounded-lg p-2 text-sm font-medium cursor-pointer"
-              onClick={() => setTabValue("code")}
-            >
-              <p>
-                <span className="font-bold">New!</span> Create a custom
-                background with a prompt.
-              </p>
-              {/* <HiOutlineSparkles size={32} /> */}
-              <SparklesIcon className="size-8" />
-            </div>
-          )}
 
           {/* Actions */}
           <div className="shrink-0 flex flex-col gap-3 pb-8">


### PR DESCRIPTION
## Summary
- add IconSelector, MiniAppSettings and MobileSettings components
- replace theme editor tabs with Space/Fidgets/Mobile
- update EditorPanel to pass fidget data for mobile settings

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*