### PR TITLE
Add hook and store tests

### DIFF
--- a/tests/generateContractMetadataHtml.test.ts
+++ b/tests/generateContractMetadataHtml.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { generateContractMetadataHtml } from '@/common/lib/utils/generateContractMetadataHtml';
+import { MasterToken } from '@/common/providers/TokenProvider';
+
+describe('generateContractMetadataHtml', () => {
+  it('creates metadata with price', () => {
+    const tokenData: MasterToken = {
+      network: 'mainnet',
+      geckoData: { symbol: 'TEST', price_usd: 1.23 } as any,
+      clankerData: { symbol: 'T' } as any,
+    };
+
+    const metadata = generateContractMetadataHtml('0xabc', tokenData);
+
+    expect(metadata.title).toBe('T - $1.23 USD');
+    expect(metadata.openGraph?.title).toBe(metadata.title);
+    expect(metadata.openGraph?.url).toBe('https://nounspace.com/t/mainnet/0xabc');
+    expect(metadata.twitter?.title).toBe(metadata.title);
+  });
+
+  it('handles missing price data', () => {
+    const tokenData: MasterToken = {
+      network: 'base',
+      geckoData: null,
+      clankerData: { symbol: 'B' } as any,
+    };
+
+    const metadata = generateContractMetadataHtml('0xdef', tokenData);
+
+    expect(metadata.title).toBe('B');
+    expect(metadata.openGraph?.url).toBe('https://nounspace.com/t/base/0xdef');
+  });
+});

--- a/tests/setupStore.test.ts
+++ b/tests/setupStore.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createSetupStoreFunc, setupStoreDefaults, SetupStep, SetupStore } from '@/common/data/stores/app/setup';
+import { StoreSet, StoreGet } from '@/common/data/stores/createStore';
+import type { AppStore } from '@/common/data/stores/app';
+
+describe('setup store', () => {
+  let state: AppStore;
+  let store: SetupStore;
+
+  beforeEach(() => {
+    state = { setup: { ...setupStoreDefaults } } as unknown as AppStore;
+    const set: StoreSet<AppStore> = (fn) => {
+      (fn as any)(state as any);
+    };
+    const get: StoreGet<AppStore> = () => state;
+    store = createSetupStoreFunc(set, get);
+  });
+
+  it('updates currentStep', () => {
+    store.setCurrentStep(SetupStep.SIGNED_IN);
+    expect(state.setup.currentStep).toBe(SetupStep.SIGNED_IN);
+  });
+
+  it('modal respects keepModalOpen', () => {
+    store.setKeepModalOpen(true);
+    store.setModalOpen(false);
+    expect(state.setup.modalOpen).toBe(true);
+  });
+});

--- a/tests/toastStore.test.ts
+++ b/tests/toastStore.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { useToastStore } from '@/common/data/stores/toastStore';
+import { JSDOM } from 'jsdom';
+
+describe('toast store', () => {
+  beforeEach(() => {
+    const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'https://test.com' });
+    (global as any).window = dom.window as any;
+    (global as any).document = dom.window.document;
+    (global as any).localStorage = dom.window.localStorage;
+    useToastStore.setState({
+      isDisplayed: false,
+      message: '',
+      duration: 5000,
+      toastKey: undefined,
+      closeForever: undefined,
+      closedForeverKeys: new Set(),
+    });
+  });
+
+  afterEach(() => {
+    delete (global as any).window;
+    delete (global as any).document;
+    delete (global as any).localStorage;
+  });
+
+  it('shows and hides a toast', () => {
+    const { showToast, hideToast } = useToastStore.getState();
+    showToast('hello', 1000);
+    expect(useToastStore.getState().isDisplayed).toBe(true);
+    expect(useToastStore.getState().message).toBe('hello');
+    hideToast();
+    expect(useToastStore.getState().isDisplayed).toBe(false);
+    expect(useToastStore.getState().message).toBe('');
+  });
+
+  it('closeForever prevents future toasts', () => {
+    const { showToast, hideToast } = useToastStore.getState();
+    showToast('persist', 1000, 'k1', true);
+    hideToast();
+    expect(useToastStore.getState().closedForeverKeys.has('k1')).toBe(true);
+    showToast('persist', 1000, 'k1', true);
+    expect(useToastStore.getState().isDisplayed).toBe(false);
+    expect(localStorage.getItem('closedForeverToasts')).toContain('k1');
+  });
+});

--- a/tests/useGraphqlQuery.test.tsx
+++ b/tests/useGraphqlQuery.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import { JSDOM } from 'jsdom';
+import useGraphqlQuery from '@/common/lib/hooks/useGraphqlQuery';
+
+describe('useGraphqlQuery', () => {
+  let container: HTMLElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    const dom = new JSDOM('<!doctype html><html><body></body></html>');
+    (global as any).window = dom.window as any;
+    (global as any).document = dom.window.document;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    root.unmount();
+    vi.restoreAllMocks();
+    delete (global as any).window;
+    delete (global as any).document;
+  });
+
+  it('fetches and returns data', async () => {
+    const responseData = { hello: 'world' };
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: responseData }),
+    } as any);
+
+    let result: ReturnType<typeof useGraphqlQuery>;
+
+    function Test() {
+      result = useGraphqlQuery({ url: '/graphql', query: 'query { hello }' });
+      return null;
+    }
+
+    await act(async () => {
+      root.render(<Test />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result!.loading).toBe(false);
+    expect(result!.data).toEqual(responseData);
+    expect(result!.error).toBeNull();
+  });
+
+  it('skips fetch when skip is true', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch');
+    let result: ReturnType<typeof useGraphqlQuery>;
+
+    function Test() {
+      result = useGraphqlQuery({ url: '/graphql', query: 'query', skip: true });
+      return null;
+    }
+
+    await act(async () => {
+      root.render(<Test />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result!.data).toBeNull();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
 
 export default defineConfig({
   test: {
-    environment: 'node',
+    environment: 'jsdom',
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+    },
   },
 })


### PR DESCRIPTION
## Summary
- add vitest alias and jsdom config
- test `useGraphqlQuery` hook
- test `generateContractMetadataHtml` utility
- test Zustand stores (`toastStore` and `setup`)

## Testing
- `npm run lint`
- `npm run check-types`
- `npm test`