### PR TITLE
Enable proposal space customization

### DIFF
--- a/src/app/(spaces)/p/[proposalId]/ProposalDefinedSpace.tsx
+++ b/src/app/(spaces)/p/[proposalId]/ProposalDefinedSpace.tsx
@@ -38,14 +38,13 @@ const ProposalDefinedSpace = ({
   return (
     <div className="w-full">
       <PublicSpace
-        spaceId={spaceId || ""} // Ensure spaceId is a string
-        tabName={tabName || "Profile"} // Ensure tabName is a string
+        spaceId={spaceId || `proposal:${proposalId}`}
+        tabName={tabName || "Overview"}
         initialConfig={INITIAL_SPACE_CONFIG}
         getSpacePageUrl={getSpacePageUrl}
-        isTokenPage={false}
-        spaceOwnerFid={1}
         spaceOwnerAddress={ownerId}
         pageType="proposal"
+        proposalId={proposalId || undefined}
       />
     </div>
   );

--- a/src/common/components/molecules/ClaimButtonWithModal.tsx
+++ b/src/common/components/molecules/ClaimButtonWithModal.tsx
@@ -12,15 +12,20 @@ import { Address } from "viem";
 
 interface ClaimButtonWithModalProps {
   contractAddress?: Address;
+  tokenSymbol?: string;
 }
 
 const ClaimButtonWithModal: React.FC<ClaimButtonWithModalProps> = ({
   contractAddress,
+  tokenSymbol,
 }) => {
   const [isModalOpen, setModalOpenState] = React.useState(false);
   const { tokenData } = useToken();
   const symbol =
-    tokenData?.clankerData?.symbol || tokenData?.geckoData?.symbol || "";
+    tokenSymbol ||
+    tokenData?.clankerData?.symbol ||
+    tokenData?.geckoData?.symbol ||
+    "";
 
   const handleClaimClick = () => {
     setModalOpenState(true);
@@ -45,8 +50,9 @@ const ClaimButtonWithModal: React.FC<ClaimButtonWithModalProps> = ({
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            Log in with the Farcaster account that deployed ${symbol} to
-            customize this space.
+            {symbol
+              ? `Log in with the Farcaster account that deployed ${symbol} to customize this space.`
+              : 'Log in with Farcaster to customize this space.'}
           </TooltipContent>
         </Tooltip>
       </div>

--- a/src/common/components/molecules/ClaimModal.tsx
+++ b/src/common/components/molecules/ClaimModal.tsx
@@ -29,8 +29,14 @@ const ClaimModal: React.FC<ClaimModalProps> = ({
     <Modal
       open={isModalOpen}
       setOpen={handleModalClose}
-      title={`Claim ${tokenSymbol}'s Token Space`}
-      description={`Login in with the Farcaster Account that deployed ${tokenSymbol} to customize this space.`}
+      title={
+        tokenSymbol ? `Claim ${tokenSymbol}'s Token Space` : 'Claim this Space'
+      }
+      description={
+        tokenSymbol
+          ? `Login in with the Farcaster Account that deployed ${tokenSymbol} to customize this space.`
+          : 'Log in with Farcaster to customize this space.'
+      }
     >
       <video
         autoPlay

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -236,9 +236,14 @@ function TabBar({
             </Reorder.Group>
           )}
         </div>
-        {isTokenPage && !getIsInitializing() && !isLoggedIn && !isMobile && (
-          <ClaimButtonWithModal contractAddress={contractAddress} />
-        )}
+        {(isTokenPage || pageType === "proposal") &&
+          !getIsInitializing() &&
+          !isLoggedIn &&
+          !isMobile && (
+            <ClaimButtonWithModal
+              contractAddress={isTokenPage ? contractAddress : undefined}
+            />
+          )}
         {inEditMode ? (
           <div className="mr-36 flex flex-row z-infinity">
             <NogsGateButton

--- a/src/common/data/stores/app/space/spaceStore.ts
+++ b/src/common/data/stores/app/space/spaceStore.ts
@@ -997,7 +997,7 @@ export const createSpaceStoreFunc = (
       // Register a new space for the proposal
       const unsignedRegistration: Omit<SpaceRegistrationProposer, "signature"> = {
         identityPublicKey: get().account.currentSpaceIdentityPublicKey!,
-        spaceName: `Proposal-${proposalId}`,
+        spaceName: `Nouns Prop ${proposalId}`,
         timestamp: moment().toISOString(),
         proposalId,
       };
@@ -1014,13 +1014,19 @@ export const createSpaceStoreFunc = (
 
       // Initialize the space with proper structure
       set((draft) => {
-        draft.space.editableSpaces[newSpaceId] = `Proposal-${proposalId}`;
+        draft.space.editableSpaces[newSpaceId] = `Nouns Prop ${proposalId}`;
         draft.space.localSpaces[newSpaceId] = {
           id: newSpaceId,
           updatedAt: moment().toISOString(),
           tabs: {},
           order: [],
           changedNames: {},
+        };
+        draft.space.remoteSpaces[newSpaceId] = {
+          id: newSpaceId,
+          updatedAt: moment().toISOString(),
+          tabs: {},
+          order: [],
         };
       });
 


### PR DESCRIPTION
## Summary
- make Claim modal generic if no token symbol
- extend claim button for proposal spaces
- update TabBar to show claim option on proposals
- register and edit proposal spaces using proposer address
- support proposal pages in PublicSpace
- generate default proposal space id and tab names

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definition files)*