### PR TITLE
Fix proposal space registration and claim modal

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -349,7 +349,7 @@ export default function PublicSpace({
     // Only proceed with registration if we're sure the space doesn't exist and FID is linked
     if (
       editabilityCheck.isEditable &&
-      isNil(currentSpaceId) &&
+      (!currentSpaceId || !localSpaces[currentSpaceId]) &&
       !isNil(currentUserFid) &&
       !loading &&
       !editabilityCheck.isLoading

--- a/src/common/components/molecules/ClaimButtonWithModal.tsx
+++ b/src/common/components/molecules/ClaimButtonWithModal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { Button } from "../atoms/button";
 import ClaimModal from "./ClaimModal";

--- a/src/common/components/molecules/ClaimModal.tsx
+++ b/src/common/components/molecules/ClaimModal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import Modal from "../molecules/Modal";
 import { Button } from "../atoms/button";


### PR DESCRIPTION
## Summary
- mark claim modal components as client components
- properly check for unregistered proposal spaces before registering them

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definitions)*