### PR TITLE
Fix proposal space editing

### DIFF
--- a/src/pages/api/space/registry/[spaceId]/index.ts
+++ b/src/pages/api/space/registry/[spaceId]/index.ts
@@ -128,28 +128,34 @@ export async function identitiesCanModifySpace(
   spaceId: string,
   network?: string,
 ) {
-  // console.log(
-  //   "Checking identities that can modify space",
-  //   stringify(spaceId),
-  //   network,
-  //   "network",
-  // );
   const supabase = createSupabaseServerClient();
   const { data: spaceRegistrationData } = await supabase
     .from("spaceRegistrations")
-    .select("contractAddress")
+    .select("contractAddress,fid,identityPublicKey")
     .eq("spaceId", spaceId);
-  if (spaceRegistrationData === null || spaceRegistrationData.length === 0)
+
+  if (spaceRegistrationData === null || spaceRegistrationData.length === 0) {
     return [];
-  const contractAddress = first(spaceRegistrationData)!.contractAddress;
+  }
+
+  const {
+    contractAddress,
+    fid,
+    identityPublicKey,
+  } = first(spaceRegistrationData)!;
+
   if (!isNull(contractAddress)) {
     return await loadIdentitiesOwningContractSpace(
       contractAddress,
       String(network),
     );
-  } else {
+  }
+
+  if (!isNull(fid)) {
     return await loadOwnedItentitiesForSpaceByFid(spaceId);
   }
+
+  return [identityPublicKey];
 }
 
 async function spacePublicKeys(req: NextApiRequest, res: NextApiResponse) {

--- a/src/pages/api/space/registry/index.ts
+++ b/src/pages/api/space/registry/index.ts
@@ -269,8 +269,10 @@ async function listModifiableSpaces(
   }
   const { data, error } = await createSupabaseServerClient()
     .from("spaceRegistrations")
-    .select("*, fidRegistrations!inner (fid, identityPublicKey)")
-    .filter("fidRegistrations.identityPublicKey", "eq", identity);
+    .select("*, fidRegistrations(fid, identityPublicKey)")
+    .or(
+      `fidRegistrations.identityPublicKey.eq.${identity},identityPublicKey.eq.${identity}`,
+    );
 
   if (error) {
     console.error("Error fetching modifiable spaces:", error.message);


### PR DESCRIPTION
## Summary
- allow edits to proposal spaces by checking registered identity
- return proposal spaces when listing modifiable spaces

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*