### PR TITLE
Fix proposal space registration handling

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -210,6 +210,18 @@ export default function PublicSpace({
         return;
       }
     } else if (resolvedPageType === "proposal" && proposalId) {
+      const existingSpace = Object.values(localSpaces).find(
+        (space) => space.proposalId === proposalId,
+      );
+
+      if (existingSpace) {
+        setCurrentSpaceId(existingSpace.id);
+        setCurrentTabName(
+          providedTabName ? decodeURIComponent(providedTabName) : "Overview",
+        );
+        return;
+      }
+
       const generatedId = `proposal:${proposalId}`;
       setCurrentSpaceId(generatedId);
       setCurrentTabName(
@@ -230,6 +242,7 @@ export default function PublicSpace({
     contractAddress,
     tokenData?.network,
     spaceOwnerFid,
+    proposalId,
     localSpaces,
   ]);
 
@@ -424,7 +437,7 @@ export default function PublicSpace({
             });
           } else if (resolvedPageType === "proposal" && proposalId) {
             console.log("Attempting to register proposal space:", { proposalId });
-            newSpaceId = await registerProposalSpace(proposalId);
+            newSpaceId = await registerProposalSpace(proposalId, initialConfig);
             console.log("Proposal space registration result:", newSpaceId);
           } else if (!isTokenPage) {
             console.log("Attempting to register user space:", {

--- a/src/common/data/stores/app/space/spaceStore.ts
+++ b/src/common/data/stores/app/space/spaceStore.ts
@@ -94,6 +94,7 @@ interface CachedSpace {
   orderUpdatedAt?: string;
   contractAddress?: string | null;
   network?: string | null;
+  proposalId?: string | null;
 }
 
 interface LocalSpace extends CachedSpace {
@@ -176,6 +177,7 @@ interface SpaceActions {
   ) => Promise<string | undefined>;
   registerProposalSpace: (
     proposalId: string,
+    initialConfig: Omit<SpaceConfig, "isEditable">,
   ) => Promise<string | undefined>;
   clear: () => void;
 }
@@ -972,7 +974,7 @@ export const createSpaceStoreFunc = (
       throw e;
     }
   },
-  registerProposalSpace: async (proposalId) => {
+  registerProposalSpace: async (proposalId, initialConfig) => {
     try {
       // Check if a space already exists for this proposal
       const { data: existingSpaces } = await axiosBackend.get<ModifiableSpacesResponse>(
@@ -1021,12 +1023,14 @@ export const createSpaceStoreFunc = (
           tabs: {},
           order: [],
           changedNames: {},
+          proposalId,
         };
         draft.space.remoteSpaces[newSpaceId] = {
           id: newSpaceId,
           updatedAt: moment().toISOString(),
           tabs: {},
           order: [],
+          proposalId,
         };
       });
 
@@ -1034,7 +1038,7 @@ export const createSpaceStoreFunc = (
       await get().space.createSpaceTab(
         newSpaceId,
         "Overview",
-        INITIAL_SPACE_CONFIG_EMPTY
+        initialConfig ?? INITIAL_SPACE_CONFIG_EMPTY
       );
 
 

--- a/src/pages/api/space/registry/[spaceId]/index.ts
+++ b/src/pages/api/space/registry/[spaceId]/index.ts
@@ -137,18 +137,22 @@ export async function identitiesCanModifySpace(
   const supabase = createSupabaseServerClient();
   const { data: spaceRegistrationData } = await supabase
     .from("spaceRegistrations")
-    .select("contractAddress")
+    .select("contractAddress, fid, identityPublicKey")
     .eq("spaceId", spaceId);
   if (spaceRegistrationData === null || spaceRegistrationData.length === 0)
     return [];
-  const contractAddress = first(spaceRegistrationData)!.contractAddress;
+  const registration = first(spaceRegistrationData)!;
+  const contractAddress = registration.contractAddress;
+  const fid = registration.fid;
   if (!isNull(contractAddress)) {
     return await loadIdentitiesOwningContractSpace(
       contractAddress,
       String(network),
     );
-  } else {
+  } else if (!isNull(fid)) {
     return await loadOwnedItentitiesForSpaceByFid(spaceId);
+  } else {
+    return [registration.identityPublicKey];
   }
 }
 


### PR DESCRIPTION
## Summary
- add proposalId to space store definitions
- preserve proposalId on proposal space registration
- reuse registered proposal spaces when visiting proposal pages
- ensure proposer can modify their proposal space by including identity key fallback
- pass initial config when creating proposal space

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definition files)*