### PR TITLE
Fix proposal page tab routing

### DIFF
--- a/src/app/(spaces)/p/[proposalId]/[tabname]/page.tsx
+++ b/src/app/(spaces)/p/[proposalId]/[tabname]/page.tsx
@@ -9,11 +9,13 @@ import { loadProposalData } from "../utils";
 
 export default async function WrapperProposalPrimarySpace({ params }) {
   const proposalId = params?.proposalId as string;
+  const tabName = params?.tabname as string | undefined;
   const proposalData = await loadProposalData(proposalId || "0");
 
   const props = {
     ...proposalData,
     proposalId,
+    tabName,
   };
 
   return (


### PR DESCRIPTION
## Summary
- pass tab name param to proposal-defined space

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: Cannot find type definition files)*