### PR TITLE
Add mobile preview mode to Theme Editor

### DIFF
--- a/src/app/(spaces)/SpacePage.tsx
+++ b/src/app/(spaces)/SpacePage.tsx
@@ -21,24 +21,41 @@ export default function SpacePage({
   profile,
   feed,
 }: SpacePageArgs) {
-  const { editMode, setEditMode, setSidebarEditable, portalRef } =
-    useSidebarContext();
+  const {
+    editMode,
+    setEditMode,
+    setSidebarEditable,
+    portalRef,
+    mobilePreview,
+  } = useSidebarContext();
+
+  const spaceElement = (
+    <Space
+      config={config}
+      saveConfig={saveConfig}
+      commitConfig={commitConfig}
+      resetConfig={resetConfig}
+      tabBar={tabBar}
+      profile={profile}
+      feed={feed}
+      setEditMode={setEditMode}
+      editMode={editMode}
+      setSidebarEditable={setSidebarEditable}
+      portalRef={portalRef}
+    />
+  );
 
   return (
-    <>
-      <Space
-        config={config}
-        saveConfig={saveConfig}
-        commitConfig={commitConfig}
-        resetConfig={resetConfig}
-        tabBar={tabBar}
-        profile={profile}
-        feed={feed}
-        setEditMode={setEditMode}
-        editMode={editMode}
-        setSidebarEditable={setSidebarEditable}
-        portalRef={portalRef}
-      />
-    </>
+    <div
+      className={
+        mobilePreview ? "flex items-center justify-center w-full h-full" : ""
+      }
+    >
+      <div
+        className={mobilePreview ? "w-[390px] h-[844px] border" : "w-full h-full"}
+      >
+        {spaceElement}
+      </div>
+    </div>
   );
 }

--- a/src/common/components/organisms/Sidebar.tsx
+++ b/src/common/components/organisms/Sidebar.tsx
@@ -17,6 +17,8 @@ export type SidebarContextValue = {
   setEditMode: (value: boolean) => void;
   sidebarEditable: boolean;
   setSidebarEditable: (value: boolean) => void;
+  mobilePreview: boolean;
+  setMobilePreview: (value: boolean) => void;
   portalRef: React.RefObject<HTMLDivElement>;
 };
 
@@ -29,6 +31,7 @@ export const SidebarContextProvider: React.FC<SidebarContextProviderProps> = ({
 }) => {
   const [editMode, setEditMode] = useState(false);
   const [sidebarEditable, setSidebarEditable] = useState(false);
+  const [mobilePreview, setMobilePreview] = useState(false);
   const portalRef = useRef<HTMLDivElement>(null);
 
   const value = useMemo(
@@ -37,9 +40,11 @@ export const SidebarContextProvider: React.FC<SidebarContextProviderProps> = ({
       setEditMode,
       sidebarEditable,
       setSidebarEditable,
+      mobilePreview,
+      setMobilePreview,
       portalRef,
     }),
-    [editMode, sidebarEditable, portalRef],
+    [editMode, sidebarEditable, mobilePreview, portalRef],
   );
 
   return (

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -51,6 +51,7 @@ import { CompleteFidgets } from "@/fidgets";
 import { DEFAULT_FIDGET_ICON_MAP } from "@/constants/mobileFidgetIcons";
 import MobileSettings from "@/common/components/organisms/MobileSettings";
 import { MiniApp } from "@/common/components/molecules/MiniAppSettings";
+import { useSidebarContext } from "@/common/components/organisms/Sidebar";
 
 export type ThemeSettingsEditorArgs = {
   theme: ThemeSettings;
@@ -72,6 +73,14 @@ export function ThemeSettingsEditor({
   const [showConfirmCancel, setShowConfirmCancel] = useState(false);
   const [activeTheme, setActiveTheme] = useState(theme.id);
   const [tabValue, setTabValue] = useState("space");
+  const { setMobilePreview } = useSidebarContext();
+
+  useEffect(() => {
+    setMobilePreview(tabValue === "mobile");
+  }, [tabValue, setMobilePreview]);
+
+  // Ensure preview is reset on unmount
+  useEffect(() => () => setMobilePreview(false), [setMobilePreview]);
 
   const miniApps = useMemo<MiniApp[]>(() => {
     return Object.values(fidgetInstanceDatums).map((d, i) => {


### PR DESCRIPTION
## Summary
- extend `SidebarContext` with mobile preview state
- trigger mobile preview when the theme editor's mobile tab is selected
- keep the space component mounted and size it for mobile preview

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*