### PR TITLE
Add initial scroll setting for iframe fidget

### DIFF
--- a/src/common/components/molecules/IframeScrollPositionSlider.tsx
+++ b/src/common/components/molecules/IframeScrollPositionSlider.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import WidthSlider, { WidthSliderProps } from "@/common/components/molecules/ScaleSliderSelector";
+
+const IframeScrollPositionSlider: React.FC<Omit<WidthSliderProps, "min" | "max" | "step">> = (props) => {
+  return <WidthSlider {...props} min={0} max={1000} step={10} />;
+};
+
+export default IframeScrollPositionSlider;

--- a/src/fidgets/ui/IFrame.tsx
+++ b/src/fidgets/ui/IFrame.tsx
@@ -1,4 +1,5 @@
 import IFrameWidthSlider from "@/common/components/molecules/IframeScaleSlider";
+import IframeScrollPositionSlider from "@/common/components/molecules/IframeScrollPositionSlider";
 import TextInput from "@/common/components/molecules/TextInput";
 import {
   FidgetArgs,
@@ -9,12 +10,13 @@ import {
 import useSafeUrl from "@/common/lib/hooks/useSafeUrl";
 import { isValidUrl } from "@/common/lib/utils/url";
 import { defaultStyleFields, ErrorWrapper, transformUrl, WithMargin } from "@/fidgets/helpers";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef, useCallback } from "react";
 import { BsCloud, BsCloudFill } from "react-icons/bs";
 
 export type IFrameFidgetSettings = {
   url: string;
   size: number;
+  scrollPosition: number;
 } & FidgetSettingsStyle;
 
 const DISALLOW_URL_PATTERNS = [
@@ -56,6 +58,19 @@ const frameConfig: FidgetProperties = {
       ),
       group: "style",
     },
+    {
+      fieldName: "scrollPosition",
+      displayName: "Initial Scroll Position",
+      displayNameHint: "Set the starting scroll position of the website.",
+      required: false,
+      inputSelector: (props) => (
+        <WithMargin>
+          <IframeScrollPositionSlider {...props} />
+        </WithMargin>
+      ),
+      group: "style",
+      default: 0,
+    },
   ],
   size: {
     minHeight: 2,
@@ -66,7 +81,7 @@ const frameConfig: FidgetProperties = {
 };
 
 const IFrame: React.FC<FidgetArgs<IFrameFidgetSettings>> = ({
-  settings: { url, size = 1 },
+  settings: { url, size = 1, scrollPosition = 0 },
 }) => {
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
@@ -75,11 +90,25 @@ const IFrame: React.FC<FidgetArgs<IFrameFidgetSettings>> = ({
     url?: string;
     iframelyHtml?: string | null;
   } | null>(null);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  const applyScrollPosition = useCallback(() => {
+    if (!iframeRef.current) return;
+    try {
+      iframeRef.current.contentWindow?.scrollTo({ top: scrollPosition });
+    } catch (err) {
+      console.error("Error setting scroll position:", err);
+    }
+  }, [scrollPosition]);
 
   const isValid = isValidUrl(url);
   const sanitizedUrl = useSafeUrl(url, DISALLOW_URL_PATTERNS);
   const transformedUrl = transformUrl(sanitizedUrl || "");
   const scaleValue = size;
+
+  useEffect(() => {
+    applyScrollPosition();
+  }, [applyScrollPosition]);
 
   useEffect(() => {
     async function checkEmbedInfo() {
@@ -150,6 +179,8 @@ const IFrame: React.FC<FidgetArgs<IFrameFidgetSettings>> = ({
         className="h-[calc(100dvh-156px)] md:h-full"
       >
         <iframe
+          ref={iframeRef}
+          onLoad={applyScrollPosition}
           src={transformedUrl}
           title="IFrame Fidget"
           sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"


### PR DESCRIPTION
## Summary
- add a new `IframeScrollPositionSlider` component
- expose `scrollPosition` setting in the iframe fidget
- apply scroll position to the embedded site on load and when updated

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definitions)*