### PR TITLE
Fix theme editor mobile preview

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -346,17 +346,27 @@ export default function Space({
     </div>
   );
 
+  if (showMobileContainer) {
+    return (
+      <div className="flex justify-center w-full h-full">
+        <div className="user-theme-background relative w-[390px] h-[844px] flex flex-col">
+          <CustomHTMLBackground
+            html={config.theme?.properties.backgroundHTML}
+            className="absolute inset-0 pointer-events-none"
+          />
+          <div className="w-full transition-all duration-100 ease-out">
+            {mainContent}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="user-theme-background w-full h-full relative flex-col">
       <CustomHTMLBackground html={config.theme?.properties.backgroundHTML} />
       <div className="w-full transition-all duration-100 ease-out">
-        {showMobileContainer ? (
-          <div className="flex justify-center">
-            <div className="w-[390px] h-[844px]">{mainContent}</div>
-          </div>
-        ) : (
-          mainContent
-        )}
+        {mainContent}
       </div>
     </div>
   );

--- a/src/common/components/organisms/EditorPanel.tsx
+++ b/src/common/components/organisms/EditorPanel.tsx
@@ -118,7 +118,7 @@ export const EditorPanel: React.FC<EditorPanelProps> = ({
   return (
     <aside
       id="logo-sidebar"
-      className="h-screen flex-row flex bg-white transition-transform -translate-x-full sm:translate-x-0"
+      className="h-screen flex-row flex bg-white transition-transform -translate-x-full sm:translate-x-0 z-50"
       aria-label="Sidebar"
     >
       <div className="flex-1 w-[270px] h-full max-h-screen pt-12 flex-col flex px-4 py-4 overflow-y-auto border-r">


### PR DESCRIPTION
## Summary
- keep the EditorPanel visible during mobile preview
- contain user theme backgrounds inside the preview container

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definitions)*