### PR TITLE
Add price to token thumbnail metadata

### DIFF
--- a/src/app/(spaces)/t/[network]/[contractAddress]/layout.tsx
+++ b/src/app/(spaces)/t/[network]/[contractAddress]/layout.tsx
@@ -45,10 +45,17 @@ export async function generateMetadata({
     marketCap = tokenData?.market_cap_usd || "";
     priceChange = tokenData?.priceChange || "";
     
-    // Get price from tokenData
-    price = tokenData?.price_usd 
-      ? `$${Number(tokenData.price_usd).toFixed(2)}` 
-      : "";
+    // Format price with extra precision for small values
+    if (tokenData?.price_usd) {
+      const priceNumber = Number(tokenData.price_usd);
+      const formatted = priceNumber.toLocaleString(undefined, {
+        minimumFractionDigits: priceNumber < 0.01 ? 4 : 2,
+        maximumFractionDigits: priceNumber < 0.01 ? 6 : 2,
+      });
+      price = `$${formatted}`;
+    } else {
+      price = "";
+    }
   } catch (error) {
     console.error("Error fetching token data for frame metadata:", error);
   }
@@ -68,6 +75,7 @@ export async function generateMetadata({
     imageUrl,
     address: contractAddress,
     marketCap,
+    price,
     priceChange,
   });
 
@@ -95,6 +103,7 @@ export async function generateMetadata({
     imageUrl,
     contractAddress,
     marketCap,
+    price,
     priceChange,
     network,
   });

--- a/src/common/lib/utils/tokenMetadata.tsx
+++ b/src/common/lib/utils/tokenMetadata.tsx
@@ -8,6 +8,7 @@ export type TokenMetadata = {
   imageUrl?: string;
   contractAddress?: string;
   marketCap?: string;
+  price?: string;
   priceChange?: string;
   network?: string;
 };
@@ -25,6 +26,7 @@ export const getTokenMetadataStructure = (
     imageUrl,
     contractAddress,
     marketCap,
+    price,
     priceChange,
     network,
   } = token;
@@ -41,6 +43,7 @@ export const getTokenMetadataStructure = (
     imageUrl: imageUrl || "",
     address: contractAddress || "",
     marketCap: marketCap || "",
+    price: price || "",
     priceChange: priceChange || "",
   });
 
@@ -61,9 +64,10 @@ export const getTokenMetadataStructure = (
     },
   };
 
-  if (marketCap || priceChange) {
+  if (marketCap || priceChange || price) {
     const descParts: string[] = [];
     if (marketCap) descParts.push(`Market Cap: $${marketCap}`);
+    if (price) descParts.push(`Price: ${price}`);
     if (priceChange) descParts.push(`24h: ${priceChange}%`);
     const description = descParts.join(" | ");
     merge(metadata, {

--- a/src/pages/api/metadata/token.tsx
+++ b/src/pages/api/metadata/token.tsx
@@ -12,6 +12,7 @@ interface TokenCardData {
   imageUrl: string;
   address: string;
   marketCap: string;
+  price: string;
   priceChange: string;
 }
 
@@ -30,6 +31,7 @@ export default async function GET(
     imageUrl: params.get("imageUrl") || "",
     address: params.get("address") || "",
     marketCap: params.get("marketCap") || "",
+    price: params.get("price") || "",
     priceChange: params.get("priceChange") || "",
   };
 
@@ -47,6 +49,14 @@ const TokenCard = ({ data }: { data: TokenCardData }) => {
         maximumFractionDigits: 2,
       })}`
     : data.marketCap;
+
+  const priceNumber = parseFloat(data.price.replace(/[$,]/g, ""));
+  const formattedPrice = Number.isFinite(priceNumber)
+    ? `$${priceNumber.toLocaleString(undefined, {
+        minimumFractionDigits: priceNumber < 0.01 ? 4 : 2,
+        maximumFractionDigits: priceNumber < 0.01 ? 6 : 2,
+      })}`
+    : data.price;
 
   const priceChangeNumber = Number(data.priceChange);
   const priceChangeColor = Number.isFinite(priceChangeNumber)
@@ -91,11 +101,14 @@ const TokenCard = ({ data }: { data: TokenCardData }) => {
       >
         <span style={{ fontSize: "56px", fontWeight: "bold" }}>{data.name}</span>
         <span style={{ fontSize: "42px", color: "white" }}>{`$${data.symbol}`}</span>
+        <span style={{ fontSize: "28px" }}>
+          Price: {formattedPrice}{" "}
+          <span style={{ color: priceChangeColor }}>
+            ({formattedPriceChange}% 24h)
+          </span>
+        </span>
         <span style={{ fontSize: "28px" }}>Address: {data.address}</span>
         <span style={{ fontSize: "28px" }}>Market Cap: {formattedMarketCap}</span>
-        <span style={{ fontSize: "28px", color: priceChangeColor }}>
-          24h Change: {formattedPriceChange}%
-        </span>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- include `price` field in token metadata utilities
- show token price on dynamic thumbnail image
- pass token price to metadata generator
- improve price formatting with small value precision
- remove dedicated line for daily change on token card

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*