### PR TITLE
Add TipTap starter kit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@tailwindcss/forms": "^0.5.4",
     "@tailwindcss/typography": "^0.5.10",
     "@tanstack/react-query": "^5.40.0",
+    "@tiptap/starter-kit": "^2.4.0",
     "@types/dompurify": "^3.0.5",
     "@types/express": "^4.17.21",
     "@types/lodash": "^4.17.6",


### PR DESCRIPTION
## Summary
- include `@tiptap/starter-kit` in package.json to satisfy editor imports

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definition file for 'node', 'react', and 'react-dom')*