### PR TITLE
Fix missing tiptap dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@tailwindcss/typography": "^0.5.10",
     "@tanstack/react-query": "^5.40.0",
     "@tiptap/starter-kit": "^2.4.0",
+    "@tiptap/react": "^2.4.0",
     "@types/dompurify": "^3.0.5",
     "@types/express": "^4.17.21",
     "@types/lodash": "^4.17.6",


### PR DESCRIPTION
## Summary
- add `@tiptap/react` to dependencies

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definitions)*