### PR TITLE
Fix FarcasterEmbed import

### DIFF
--- a/src/fidgets/farcaster/useTiptapEditor.ts
+++ b/src/fidgets/farcaster/useTiptapEditor.ts
@@ -5,7 +5,8 @@ import Placeholder from "@tiptap/extension-placeholder";
 import Mention from "@tiptap/extension-mention";
 import Link from "@tiptap/extension-link";
 import suggestion from "@tiptap/suggestion";
-import { Channel, FarcasterEmbed } from "./types";
+import { Channel } from "./types";
+import { FarcasterEmbed } from "./utils";
 
 interface UseTiptapEditorProps {
   onSubmit: () => Promise<boolean>;


### PR DESCRIPTION
## Summary
- fix FarcasterEmbed import path in useTiptapEditor

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definitions for `node`, `react` and `react-dom`)*