### PR TITLE
Fix mobile preview exit logic

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -79,7 +79,7 @@ export default function Space({
 }: SpaceArgs) {
   // Use the useIsMobile hook instead of duplicating logic
   const viewportMobile = useIsMobile();
-  const { mobilePreview } = useMobilePreview();
+  const { mobilePreview, setMobilePreview } = useMobilePreview();
   const isMobile = viewportMobile || mobilePreview;
   const showMobileContainer = mobilePreview && !viewportMobile;
 
@@ -188,11 +188,13 @@ export default function Space({
   function saveExitEditMode() {
     commitConfig();
     setEditMode(false);
+    setMobilePreview(false);
   }
 
   function cancelExitEditMode() {
     resetConfig();
     setEditMode(false);
+    setMobilePreview(false);
   }
 
   async function saveLocalConfig({


### PR DESCRIPTION
## Summary
- exit mobile preview when leaving edit mode

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*