### PR TITLE
[CLIENT] ensure custom backgrounds fill mobile preview

### DIFF
--- a/src/common/components/molecules/CustomHTMLBackground.tsx
+++ b/src/common/components/molecules/CustomHTMLBackground.tsx
@@ -12,7 +12,7 @@ const CustomHTMLBackground: React.FC<CustomHTMLBackgroundProps> = ({
 }) => {
   // todo: more robust sanitization
   const sanitizedHtml = useMemo(() => {
-    return DOMPurify.sanitize(html, {
+    const sanitized = DOMPurify.sanitize(html, {
       FORCE_BODY: true,
       SAFE_FOR_TEMPLATES: false,
       USE_PROFILES: {
@@ -21,6 +21,12 @@ const CustomHTMLBackground: React.FC<CustomHTMLBackgroundProps> = ({
       },
       ALLOWED_TAGS: ["style"],
     });
+
+    // ensure iframe content always fills its container
+    const baseStyles =
+      "<style>html,body{margin:0;height:100%;width:100%;}</style>";
+
+    return `${baseStyles}${sanitized}`;
   }, [html]);
 
   return sanitizedHtml ? (


### PR DESCRIPTION
## Summary
- fix `CustomHTMLBackground` to make iframe content cover its container

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6839f87f73c48325ab82065365ed2ef2