### PR TITLE
Improve web embed fidget reliability with debounce and stricter URL validation when editing

### DIFF
--- a/src/common/lib/hooks/useDebounce.ts
+++ b/src/common/lib/hooks/useDebounce.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from "react";
+
+function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+export default useDebounce;

--- a/src/common/lib/utils/url.ts
+++ b/src/common/lib/utils/url.ts
@@ -5,3 +5,16 @@ export const isValidUrl = (url: string): boolean => {
     return false;
   }
 };
+
+export const isValidHttpUrl = (url: string): boolean => {
+  try {
+    const { protocol, hostname } = new URL(url);
+
+    const hasValidProtocol = protocol === "http:" || protocol === "https:";
+    const hasValidHost = hostname.includes(".") && hostname.split(".").pop()!.length > 1;
+
+    return hasValidProtocol && hasValidHost;
+  } catch (error) {
+    return false;
+  }
+};

--- a/src/fidgets/ui/IFrame.tsx
+++ b/src/fidgets/ui/IFrame.tsx
@@ -7,7 +7,8 @@ import {
   type FidgetSettingsStyle,
 } from "@/common/fidgets";
 import useSafeUrl from "@/common/lib/hooks/useSafeUrl";
-import { isValidUrl } from "@/common/lib/utils/url";
+import useDebounce from "@/common/lib/hooks/useDebounce";
+import { isValidHttpUrl } from "@/common/lib/utils/url";
 import { defaultStyleFields, ErrorWrapper, transformUrl, WithMargin } from "@/fidgets/helpers";
 import React, { useEffect, useState } from "react";
 import { BsCloud, BsCloudFill } from "react-icons/bs";
@@ -76,21 +77,22 @@ const IFrame: React.FC<FidgetArgs<IFrameFidgetSettings>> = ({
     iframelyHtml?: string | null;
   } | null>(null);
 
-  const isValid = isValidUrl(url);
-  const sanitizedUrl = useSafeUrl(url, DISALLOW_URL_PATTERNS);
+  const debouncedUrl = useDebounce(url, 300);
+  const isValid = isValidHttpUrl(debouncedUrl);
+  const sanitizedUrl = useSafeUrl(debouncedUrl, DISALLOW_URL_PATTERNS);
   const transformedUrl = transformUrl(sanitizedUrl || "");
   const scaleValue = size;
 
   useEffect(() => {
     async function checkEmbedInfo() {
-      if (!isValid || !url) return;
+      if (!isValid || !sanitizedUrl) return;
 
       setLoading(true);
       setError(null);
 
       try {
         const response = await fetch(
-          `/api/iframely?url=${encodeURIComponent(url)}`
+          `/api/iframely?url=${encodeURIComponent(sanitizedUrl)}`
         );
         if (!response.ok) {
           const errorData = await response.json();
@@ -110,7 +112,7 @@ const IFrame: React.FC<FidgetArgs<IFrameFidgetSettings>> = ({
     }
 
     checkEmbedInfo();
-  }, [url, isValid]);
+  }, [debouncedUrl, isValid]);
 
   if (!url) {
     return <ErrorWrapper icon="➕" message="Provide a URL to display here." />;


### PR DESCRIPTION
## Summary
- prevent premature iFramely requests by debouncing URL check in Web Embed fidget
- add stricter URL validation helper
- expose reusable `useDebounce` hook

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683a21d5c6908325b2ca7361e613fb14