### PR TITLE
Fix navigation toggle position

### DIFF
--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -212,7 +212,7 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
         >
           <button
             onClick={toggleSidebar}
-            className="absolute right-0 top-[31px] transform translate-x-1/2 bg-white rounded-full border border-gray-200 shadow-sm p-2 hover:bg-gray-50 z-10"
+            className="absolute right-0 top-[30px] transform translate-x-1/2 bg-white rounded-full border border-gray-200 shadow-sm p-2 hover:bg-gray-50 z-10"
             aria-label={shrunk ? "Expand sidebar" : "Collapse sidebar"}
           >
             {shrunk ? (

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -212,7 +212,7 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
         >
           <button
             onClick={toggleSidebar}
-            className="absolute right-0 top-4 transform translate-x-1/2 bg-white rounded-full border border-gray-200 shadow-sm p-2 hover:bg-gray-50 z-10"
+            className="absolute right-0 top-[31px] transform translate-x-1/2 bg-white rounded-full border border-gray-200 shadow-sm p-2 hover:bg-gray-50 z-10"
             aria-label={shrunk ? "Expand sidebar" : "Collapse sidebar"}
           >
             {shrunk ? (


### PR DESCRIPTION
## Summary
- move sidebar toggle button down 15px

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683dde2d0a4c8325b93f27d90b6eae71