### PR TITLE
Fix cast page null params error

### DIFF
--- a/src/app/(spaces)/homebase/c/[caster]/[castHash]/page.tsx
+++ b/src/app/(spaces)/homebase/c/[caster]/[castHash]/page.tsx
@@ -6,7 +6,7 @@ import PrivateSpace from "../../../PrivateSpace";
 
 const HomebaseCastPage = () => {
   const params = useParams<{ caster: string; castHash: string }>();
-  const castHash = decodeURIComponent(params.castHash ?? "");
+  const castHash = decodeURIComponent(params?.castHash ?? "");
   return <PrivateSpace tabName="Feed" castHash={castHash} />;
 };
 


### PR DESCRIPTION
## Summary
- handle potential `null` from `useParams` on cast page

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing `@types` packages)*

------
https://chatgpt.com/codex/tasks/task_e_683dea3964708325b68114ab7864ab6a