### PR TITLE
Add notification links to cast detail

### DIFF
--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useMemo, useCallback, useEffect, Suspense } from "react";
+import { useRouter } from "next/navigation";
 import useNotifications from "@/common/lib/hooks/useNotifications";
 import useCurrentFid from "@/common/lib/hooks/useCurrentFid";
 import { FaCircleExclamation } from "react-icons/fa6";
@@ -45,7 +46,7 @@ const TAB_OPTIONS = {
 
 export type NotificationRowProps = React.FC<{
   notification: Notification;
-  onSelect: (castHash: string) => void;
+  onSelect: (castHash: string, username: string) => void;
   isUnseen?: boolean;
 }>;
 
@@ -374,13 +375,18 @@ function NotificationsPageContent() {
     identityPublicKey,
   );
 
+  const router = useRouter();
+
   const onTabChange = useCallback((value: string) => {
     setTab(value);
   }, []);
 
-  const onSelectNotification = useCallback(() => {
-    // console.log("@TODO: navigateToCastDetail"); // TODO
-  }, []);
+  const onSelectNotification = useCallback(
+    (hash: string, username: string) => {
+      router.push(`/homebase/c/${username}/${hash}`);
+    },
+    [router],
+  );
 
   const filterByType = useCallback(
     (_notifications: Notification[]): Notification[] => {


### PR DESCRIPTION
## Summary
- link notifications to homebase cast URL

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definition files)*

------
https://chatgpt.com/codex/tasks/task_e_683dfbb274ec8325a9d25bb47c0d5076