### PR TITLE
Fix like notification links

### DIFF
--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -267,6 +267,20 @@ const LikeNotificationRow: NotificationRowProps = ({
       .map((r) => r.user);
   }, [notification?.reactions]);
 
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      const selection = window.getSelection();
+      if (selection && selection.toString().length > 0) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
+      onSelect(notification.cast!.hash, notification.cast!.author.username);
+    },
+    [notification.cast, onSelect],
+  );
+
   return (
     <div className="flex flex-col gap-2">
       <NotificationHeader
@@ -275,7 +289,7 @@ const LikeNotificationRow: NotificationRowProps = ({
         descriptionSuffix="liked your cast"
         leftIcon={<FaHeart className="w-4 h-4" aria-label="Like" />}
       />
-      <div className="ml-4 w-full">
+      <div className="ml-4 w-full cursor-pointer" onClick={handleClick}>
         <CastBody
           cast={notification.cast!}
           channel={null}


### PR DESCRIPTION
## Summary
- ensure Like notifications open the cast on Homebase

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683dff433b88832597bda1e9ee1dba9e