### PR TITLE
Fix feed fidget URL behavior

### DIFF
--- a/src/app/(spaces)/homebase/PrivateSpace.tsx
+++ b/src/app/(spaces)/homebase/PrivateSpace.tsx
@@ -223,7 +223,7 @@ function PrivateSpace({ tabName, castHash }: { tabName: string; castHash?: strin
           fontColor: "var(--user-theme-font-color)" as any,
         }}
         saveData={async () => noop()}
-        data={{ initialHash: castHash }}
+        data={{ initialHash: castHash, updateUrl: true }}
       />
     ) : undefined,
   }), [

--- a/src/fidgets/farcaster/Feed.tsx
+++ b/src/fidgets/farcaster/Feed.tsx
@@ -39,6 +39,12 @@ export enum FilterType {
 
 export type FeedFidgetData = {
   initialHash?: string;
+  /**
+   * When true, selecting a cast will update the browser URL to
+   * reflect the selected cast on the homebase feed. This should
+   * only be enabled for the immutable feed on /homebase.
+   */
+  updateUrl?: boolean;
 };
 
 export type FeedFidgetSettings = {
@@ -420,15 +426,19 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings, FeedFidgetData>> = ({ settin
   const onSelectCast = useCallback(
     (hash: string, username: string) => {
       push(hash);
-      router.push(`/homebase/c/${username}/${hash}`);
+      if (initialData?.updateUrl) {
+        router.push(`/homebase/c/${username}/${hash}`);
+      }
     },
-    [push, router],
+    [push, router, initialData?.updateUrl],
   );
 
   const handleBack = useCallback(() => {
     pop();
-    router.push(`/homebase`);
-  }, [pop, router]);
+    if (initialData?.updateUrl) {
+      router.push(`/homebase`);
+    }
+  }, [pop, router, initialData?.updateUrl]);
 
   const renderThread = () => (
     <CastThreadView


### PR DESCRIPTION
## Summary
- extend `FeedFidgetData` with `updateUrl`
- only push router updates in `Feed` when `updateUrl` is true
- enable URL updates for the immutable homebase feed

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683f26049d648325a9c2c7bf36a84edf