### PR TITLE
Add client directive to CastRow

### DIFF
--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React, { useState, useCallback, useMemo } from "react";
 import { Properties } from "csstype";
 import { mergeClasses as classNames } from "@/common/lib/utils/mergeClasses";


### PR DESCRIPTION
## Summary
- mark `CastRow` as a client component

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684bd4a0ea48832595cf6eebd9c78b0b