### PR TITLE
Reduce spacing in token header and add back the divider

### DIFF
--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -203,13 +203,13 @@ function TabBar({
     <TooltipProvider>
       <div className="flex flex-col md:flex-row justify-start md:h-16 z-50 bg-white relative">
         {isTokenPage && contractAddress && (
-          <div className="flex flex-row justify-start h-16 overflow-y-scroll w-full z-30 bg-white">
+          <div className="flex flex-row justify-start h-16 overflow-y-scroll w-fit z-30 bg-white">
             <TokenDataHeader />
           </div>
         )}
         <div
           className={mergeClasses(
-            "flex flex-auto justify-start h-16 z-70 bg-white md:pr-0 flex-nowrap overflow-y-scroll",
+            "flex flex-auto justify-center h-16 z-70 bg-white md:pr-0 flex-nowrap overflow-y-scroll",
             showButtons && "w-64 pr-8",
           )}
         >
@@ -221,7 +221,7 @@ function TabBar({
                 await updateTabOrder(newOrder);
                 await commitTabOrder();
               }}
-              className="flex flex-row gap-5 md:gap-4 items-start m-4 tabs"
+              className="flex flex-row gap-5 md:gap-4 items-start m-4 tabs grow"
               values={tabList}
             >
               <AnimatePresence initial={false}>

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -203,13 +203,13 @@ function TabBar({
     <TooltipProvider>
       <div className="flex flex-col md:flex-row justify-start md:h-16 z-50 bg-white relative">
         {isTokenPage && contractAddress && (
-          <div className="flex flex-row justify-start h-16 overflow-y-scroll w-fit z-30 bg-white">
+          <div className="flex flex-row justify-start h-16 overflow-x-scroll overflow-y-hidden w-fit z-30 bg-white">
             <TokenDataHeader />
           </div>
         )}
         <div
           className={mergeClasses(
-            "flex flex-auto justify-center h-16 z-70 bg-white md:pr-0 flex-nowrap overflow-y-scroll",
+            "flex flex-auto justify-center h-16 z-70 bg-white md:pr-0 flex-nowrap overflow-x-scroll overflow-y-hidden",
             showButtons && "w-64 pr-8",
           )}
         >

--- a/src/common/components/organisms/TokenDataHeader.tsx
+++ b/src/common/components/organisms/TokenDataHeader.tsx
@@ -59,7 +59,7 @@ const TokenDataHeader: React.FC = () => {
   };
 
   return (
-    <div className="flex items-center justify-between px-3 md:px-4 py-2 w-full border-b border-b-gray-200 md:border-none">
+    <div className="flex items-center px-3 md:px-4 py-2 w-fit border-b border-b-gray-200 md:border-none space-x-2 md:space-x-4">
       <div className="flex items-center space-x-2 md:space-x-4">
         <Avatar
           style={{
@@ -172,7 +172,7 @@ const TokenDataHeader: React.FC = () => {
             onClick={handleCopyUrl}
           />
         </div>
-        <div className="w-0.5 h-12 bg-gray-200 m-5 hidden md:visible" />
+        <div className="w-0.5 h-12 bg-gray-200 m-2.5 hidden md:visible" />
       </div>
     </div>
   );

--- a/src/common/components/organisms/TokenDataHeader.tsx
+++ b/src/common/components/organisms/TokenDataHeader.tsx
@@ -172,7 +172,7 @@ const TokenDataHeader: React.FC = () => {
             onClick={handleCopyUrl}
           />
         </div>
-        <div className="w-0.5 h-12 bg-gray-200 m-2.5 hidden md:visible" />
+        <div className="w-0.5 h-12 bg-gray-200 m-2.5 hidden md:block" />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- compress spacing in TokenDataHeader so icons sit closer to the token symbol
- shrink divider margin to reclaim more space for tabs

Before:
<img width="1261" alt="image" src="https://github.com/user-attachments/assets/03c57a87-4103-45b9-b2a0-3e83d36fbdac" />

After:
<img width="1420" alt="image" src="https://github.com/user-attachments/assets/7130f4d0-eed8-4ca8-ba03-f9e660057b14" />


## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684ceba7f26c8325839259869e8c71cd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved alignment and spacing of the tab bar and token header for a more compact and visually balanced layout.
  - Centered the tab bar tabs and adjusted container widths to better fit their content.
  - Reduced spacing around the vertical divider for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->