### PR TITLE
Implement server-side iframe caching

### DIFF
--- a/src/app/api/iframely/route.ts
+++ b/src/app/api/iframely/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
+export const revalidate = 3600; // Cache responses for 1 hour
+
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const url = searchParams.get("url");
@@ -40,13 +42,14 @@ export async function GET(req: NextRequest) {
 
 async function checkEmbeddability(url: string): Promise<boolean> {
   try {
-    // Make a HEAD request to check headers
+    // Make a HEAD request to check headers and cache the result
     const response = await fetch(url, {
       method: "HEAD",
       headers: {
         // Some servers require a user-agent
         "User-Agent": "Mozilla/5.0 NounspaceBot/1.0",
       },
+      next: { revalidate: 3600 },
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- cache Iframely API route results on the server
- cache HEAD requests when checking for embeddability

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68540fec1f1c8325a461451857a71831

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved performance by enabling one-hour caching for API responses and related fetch requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->