### PR TITLE
Fix tab bar overflow

### DIFF
--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -210,7 +210,7 @@ function TabBar({
         <div
           className={mergeClasses(
             "flex flex-auto justify-start h-16 z-70 bg-white md:pr-0 flex-nowrap overflow-x-auto no-scrollbar",
-            showButtons && "w-64 pr-8",
+            showButtons && "pr-8",
           )}
         >
           {tabList && (

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -203,13 +203,13 @@ function TabBar({
     <TooltipProvider>
       <div className="flex flex-col md:flex-row justify-start md:h-16 z-50 bg-white relative">
         {isTokenPage && contractAddress && (
-          <div className="flex flex-row justify-start h-16 overflow-y-scroll w-fit z-30 bg-white">
+          <div className="flex flex-row justify-start h-16 overflow-x-auto no-scrollbar w-fit z-30 bg-white">
             <TokenDataHeader />
           </div>
         )}
         <div
           className={mergeClasses(
-            "flex flex-auto justify-center h-16 z-70 bg-white md:pr-0 flex-nowrap overflow-y-scroll",
+            "flex flex-auto justify-start h-16 z-70 bg-white md:pr-0 flex-nowrap overflow-x-auto no-scrollbar",
             showButtons && "w-64 pr-8",
           )}
         >

--- a/src/common/components/organisms/TabBarSkeleton.tsx
+++ b/src/common/components/organisms/TabBarSkeleton.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 const TabBarSkeleton: React.FC = () => {
   return (
-    <div className="flex flex-row justify-center h-16 overflow-y-scroll w-full z-50 bg-white">
+    <div className="flex flex-row justify-start h-16 overflow-x-auto no-scrollbar w-full z-50 bg-white">
       <div className="flex flex-row gap-4 grow items-start m-4 tabs">
         {Array.from({ length: 5 }).map((_, index) => (
           <div


### PR DESCRIPTION
Currently if a user has a ton of tabs, it's possible for the initial tabs to overflow on the left side of the tab bar.

## Summary
- prevent tab bar tabs from extending past left edge

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68590a4a09f08325a2ee2c15ab767cd2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the TabBar and TabBarSkeleton components to use horizontal scrolling instead of vertical scrolling.
  - Adjusted alignment from centered to left-aligned for a more streamlined layout.
  - Scrollbars are now hidden for a cleaner appearance.
  - Improved padding and spacing in the tab bar area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->