### PR TITLE
Fix sidebar layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -72,7 +72,7 @@ const sidebarLayout = (page: React.ReactNode) => {
 
         {/* Main Content with Sidebar */}
         <div className="flex w-full h-full flex-grow">
-          <div className="mx-auto transition-all duration-100 ease-out z-10 hidden md:block">
+          <div className="transition-all duration-100 ease-out z-10 hidden md:block flex-shrink-0">
             <ClientSidebarWrapper />
           </div>
           {page}

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -368,7 +368,9 @@ const Navigation: React.FC<NavProps> = ({
                   <FaDiscord className="text-[#5865f2] w-6 h-6" />
                   {!shrunk && "Join"}
                 </Link>
-                <div className="flex flex-col items-center text-xs text-gray-500">
+                <div
+                  className="flex flex-col items-center text-xs text-gray-500 mt-[10px]"
+                >
                   <Link href="/terms" className="hover:underline">
                     Terms
                   </Link>

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -223,8 +223,8 @@ const Navigation: React.FC<NavProps> = ({
             mobile
               ? "w-[270px]"
               : shrunk
-                ? "w-[90px] ml-auto"
-                : "w-[270px] ml-auto"
+              ? "w-[90px]"
+              : "w-[270px]"
           )}
         >
           {!mobile && (

--- a/src/common/components/organisms/NavigationSkeleton.tsx
+++ b/src/common/components/organisms/NavigationSkeleton.tsx
@@ -9,7 +9,7 @@ const NavigationSkeleton: React.FC = () => {
       aria-label="Sidebar Skeleton"
     >
       <div className="pt-5 pb-12 h-full md:block hidden">
-        <div className="flex flex-col h-full w-[270px] ml-auto">
+        <div className="flex flex-col h-full w-[270px]">
           <div className="flex flex-col text-lg font-medium pb-3 px-4 overflow-auto">
             <div className="flex-auto">
               <ul className="space-y-2">

--- a/src/common/components/organisms/Sidebar.tsx
+++ b/src/common/components/organisms/Sidebar.tsx
@@ -57,7 +57,7 @@ export const Sidebar: React.FC<SidebarProps> = () => {
   return (
     <>
       <div ref={portalRef} className={editMode ? "w-full" : ""}></div>
-      <div className={editMode ? "hidden" : "md:flex mx-auto h-full hidden"}>
+      <div className={editMode ? "hidden" : "md:flex h-full hidden"}>
         <Navigation isEditable={sidebarEditable} />
       </div>
     </>


### PR DESCRIPTION
## Summary
- remove margin auto around sidebar container so it's flush left
- strip auto margins from Sidebar and Navigation
- keep NavigationSkeleton aligned

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685a4ca8257c83259e1532f8509ca2bc