### PR TITLE
Fix token space tab alignment

### DIFF
--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -202,7 +202,7 @@ function TabBar({
     <TooltipProvider>
       <div className="flex flex-col md:flex-row justify-start md:h-16 z-30 bg-white w-full"> 
         {isTokenPage && contractAddress && (
-          <div className="flex flex-row justify-start h-16 overflow-y-scroll w-full z-20 bg-white"> 
+          <div className="flex flex-row justify-start h-16 overflow-y-scroll w-full md:w-fit z-20 bg-white">
             <TokenDataHeader />
           </div>
         )}
@@ -236,7 +236,7 @@ function TabBar({
                 as="ol"
                 axis="x"
                 onReorder={updateTabOrder}
-                className="flex flex-row gap-5 md:gap-4 items-start m-4 tabs"
+                className="flex flex-row gap-5 md:gap-4 items-start ml-2 my-4 mr-4 tabs"
                 values={tabList}
                 style={{
                   maxWidth: isMobile ? 'calc(100% - 60px)' : '100%',


### PR DESCRIPTION
## Summary
- adjust TokenDataHeader wrapper width so token tabs sit next to divider
- tighten left padding on token tab list

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_6866392b5cc8832589223122c0450574

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout and spacing in the TabBar for better appearance across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->