### PR TITLE
🛹 refactor: simplify useAppStore destructuring in AuthenticatorManagerProvider

### DIFF
--- a/src/authenticators/AuthenticatorManager.tsx
+++ b/src/authenticators/AuthenticatorManager.tsx
@@ -155,9 +155,10 @@ export const AuthenticatorManagerProvider: React.FC<
   }>();
   const [initializationQueue, setInitializationQueue] = useState<string[]>([]);
 
-  const {
-    setup: { setModalOpen, modalOpen },
-  } = useAppStore((state) => state);
+  const { modalOpen, setModalOpen } = useAppStore((state) => ({
+    modalOpen: state.setup.modalOpen,
+    setModalOpen: state.setup.setModalOpen
+  }));
 
   const authenticatorManager = useMemo<AuthenticatorManager>(
     () => ({


### PR DESCRIPTION
This pull request makes a small change to how state is accessed in the `AuthenticatorManagerProvider` component. The code now uses a selector function to retrieve `modalOpen` and `setModalOpen` directly from the store, improving clarity and potentially performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the way modal state is accessed within the application, resulting in cleaner and more maintainable code. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->