### PR TITLE
chore: allow goldsky and alchemy

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -37,7 +37,9 @@ const cspHeader = `
       https://auth.privy.io/api/v1/analytics_events
       https://cdn.segment.com
       https://api.segment.io
-      https://api.imgbb.com;
+      https://api.imgbb.com
+      https://api.goldsky.com
+      https://base-mainnet.g.alchemy.com;
 
     upgrade-insecure-requests;
 `;


### PR DESCRIPTION
## Summary
- expand CSP connect-src to permit Goldsky API
- allow Alchemy Base mainnet endpoint

## Testing
- `npm run lint`
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_689b93b5f07c8325b38a512eb4e95536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - Prevents browser blocks by allowing connections to additional trusted data providers.
- Chores
  - Expanded Content Security Policy to permit connections to new external services (e.g., Goldsky, Alchemy), improving integration reliability.
- Documentation
  - None.
- Tests
  - None.
- Refactor
  - None.
- Style
  - None.
- Revert
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->