### PR TITLE
🛹 Fix brandheader warning 4 the 69th time

### DIFF
--- a/src/common/components/molecules/BrandHeader.tsx
+++ b/src/common/components/molecules/BrandHeader.tsx
@@ -23,13 +23,16 @@ const BrandHeader = () => {
             rel="noopener noreferrer"
           >
             <TooltipTrigger asChild>
-              <Image
-                src="/images/noggles.svg"
-                className="h-13 me-3"
-                alt="Nounspace Logo"
-                width={60}
-                height={40}
-              />
+              <div className="w-12 h-12 sm:w-15 sm:h-13 me-3 flex items-center justify-center">
+                <Image
+                  src="/images/noggles.svg"
+                  alt="Nounspace Logo"
+                  width={60}
+                  height={40}
+                  priority
+                  className="w-full h-full object-contain"
+                />
+              </div>
             </TooltipTrigger>
           </Link>
           <TooltipContent className="bg-gray-200 font-black" side="left">

--- a/src/common/components/molecules/BrandHeader.tsx
+++ b/src/common/components/molecules/BrandHeader.tsx
@@ -23,7 +23,7 @@ const BrandHeader = () => {
             rel="noopener noreferrer"
           >
             <TooltipTrigger asChild>
-              <div className="w-12 h-12 sm:w-15 sm:h-13 me-3 flex items-center justify-center">
+              <div className="w-12 h-8 sm:w-16 sm:h-10 me-3 flex items-center justify-center">
                 <Image
                   src="/images/noggles.svg"
                   alt="Nounspace Logo"


### PR DESCRIPTION
This pull request makes a small update to the `BrandHeader` component, improving the display of the logo image for better responsiveness and alignment. The image is now wrapped in a `div` with explicit sizing and flexbox centering, and the image itself uses `object-contain` for proper scaling.

- Wrapped the logo `Image` in a flex container `div` with responsive width and height, ensuring consistent sizing and alignment across devices. (`[src/common/components/molecules/BrandHeader.tsxR26-R35](diffhunk://#diff-6d30d8b09c4f25a36dc9b25f9d9950f26298b8a6bcc7d044ca54b07a16b9b48fR26-R35)`)
- Updated the `Image` element to use `object-contain`, fill its parent container, and set `priority` for faster loading. (`[src/common/components/molecules/BrandHeader.tsxR26-R35](diffhunk://#diff-6d30d8b09c4f25a36dc9b25f9d9950f26298b8a6bcc7d044ca54b07a16b9b48fR26-R35)`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated BrandHeader logo to use a responsive container, ensuring consistent sizing and alignment across screen sizes. The image now scales within its wrapper for cleaner presentation.

* **Performance**
  * Enabled priority loading for the logo to improve initial render speed and perceived load time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->