### PR TITLE
feat: add Farcaster deeplink button

### DIFF
--- a/src/authenticators/farcaster/signers/NounspaceManagedSignerAuthenticator.tsx
+++ b/src/authenticators/farcaster/signers/NounspaceManagedSignerAuthenticator.tsx
@@ -247,8 +247,7 @@ const initializer: AuthenticatorInitializer<
       data.status === "revoked" ? (
         <>
           <p className="text-lg text-gray-500 mt-4">
-            Use of Nounspace requires a Farcaster account. Click the button
-            below to connect your Farcaster account via Warpcast.
+            Click the button below to connect your Farcaster account.
           </p>
           <Button
             style={{
@@ -293,8 +292,8 @@ const initializer: AuthenticatorInitializer<
               />
             </div>
             <p className="text-xl text-gray-500 m-5">
-              Scan the QR code with your phone camera <br /> or enter the link
-              on a mobile browser
+              Scan the QR code with your phone camera <br /> or tap the button below
+              if you're already on mobile.
             </p>
           </div>
           <div className="flex flex-col text-center mt-4">
@@ -321,7 +320,7 @@ const initializer: AuthenticatorInitializer<
               onClick={createSigner}
             >
               <FaRedo color="gray.400" />
-              Still having trouble? Reset the QR
+              Having trouble? Reset the QR
             </Button>
           </div>
         </>

--- a/src/authenticators/farcaster/signers/NounspaceManagedSignerAuthenticator.tsx
+++ b/src/authenticators/farcaster/signers/NounspaceManagedSignerAuthenticator.tsx
@@ -293,7 +293,7 @@ const initializer: AuthenticatorInitializer<
             </div>
             <p className="text-xl text-gray-500 m-5">
               Scan the QR code with your phone camera <br /> or tap the button below
-              if you're already on mobile.
+              if you&apos;re already on mobile.
             </p>
           </div>
           <div className="flex flex-col text-center mt-4">

--- a/src/authenticators/farcaster/signers/NounspaceManagedSignerAuthenticator.tsx
+++ b/src/authenticators/farcaster/signers/NounspaceManagedSignerAuthenticator.tsx
@@ -23,7 +23,6 @@ import {
 } from "@/pages/api/signerRequests";
 import QRCode from "@/common/components/atoms/qr-code";
 import { SignatureScheme } from "@farcaster/core";
-import { FaRegCopy } from "react-icons/fa6";
 import { FaRedo } from "react-icons/fa";
 import TextInput from "@/common/components/molecules/TextInput";
 
@@ -301,17 +300,18 @@ const initializer: AuthenticatorInitializer<
           <div className="flex flex-col text-center mt-4">
             <center>
               <Button
-                withIcon
                 variant="outline"
                 size="sm"
                 className="border-gray-500 text-black bg-gray-200 border-none hover:bg-gray-300 hover:text-black rounded-full"
                 style={{ width: "150px" }}
-                onClick={() => {
-                  navigator.clipboard.writeText(warpcastSignerUrl);
-                }}
+                asChild
               >
-                <FaRegCopy size={18} color="grey.500" />
-                <p className="font-bold text-lg text-gray-500">Copy URL</p>
+                <a
+                  href={data.signerUrl ?? ""}
+                  className="font-bold text-lg text-gray-500"
+                >
+                  On Mobile? Tap here
+                </a>
               </Button>
             </center>
             <Button


### PR DESCRIPTION
## Summary
- Replace copy URL option with mobile deeplink to Farcaster signer request

## Testing
- `npm run lint`
- `npm run check-types` *(fails: Module '../src/common/lib/utils/gridCleanup' has no exported member 'cleanupLayout')*
- `npm test` *(fails: cleanupLayout is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c9c480248325ab96b40f7b1b785f