### PR TITLE
Integrate Empire token data into token pages

### DIFF
--- a/src/app/(spaces)/t/[network]/DesktopContractDefinedSpace.tsx
+++ b/src/app/(spaces)/t/[network]/DesktopContractDefinedSpace.tsx
@@ -23,7 +23,10 @@ export default function DesktopContractDefinedSpace({
         contractAddress,
         tokenData?.clankerData?.cast_hash || "",
         String(tokenData?.clankerData?.requestor_fid || ""),
-        tokenData?.clankerData?.symbol || tokenData?.geckoData?.symbol || "",
+        tokenData?.clankerData?.symbol ||
+          tokenData?.empireData?.token_symbol ||
+          tokenData?.geckoData?.symbol ||
+          "",
         !!tokenData?.clankerData,
         tokenData?.network,
       ),

--- a/src/app/(spaces)/t/[network]/MobileSpace.tsx
+++ b/src/app/(spaces)/t/[network]/MobileSpace.tsx
@@ -36,7 +36,10 @@ export const MobileContractDefinedSpace = ({
   const [ref, inView] = useInView();
   const { tokenData } = useToken();
   const symbol =
-    tokenData?.clankerData?.symbol || tokenData?.geckoData?.symbol || "";
+    tokenData?.clankerData?.symbol ||
+    tokenData?.empireData?.token_symbol ||
+    tokenData?.geckoData?.symbol ||
+    "";
   const decimals = tokenData?.geckoData?.decimals || "";
   const image =
     tokenData?.clankerData?.img_url ||
@@ -52,7 +55,10 @@ export const MobileContractDefinedSpace = ({
         tokenData?.clankerData?.requestor_fid
           ? String(tokenData.clankerData.requestor_fid)
           : "",
-        tokenData?.clankerData?.symbol || tokenData?.geckoData?.symbol || "",
+        tokenData?.clankerData?.symbol ||
+          tokenData?.empireData?.token_symbol ||
+          tokenData?.geckoData?.symbol ||
+          "",
         !!tokenData?.clankerData,
         tokenData?.network,
       ),

--- a/src/app/(spaces)/t/[network]/[contractAddress]/[tabName]/page.tsx
+++ b/src/app/(spaces)/t/[network]/[contractAddress]/[tabName]/page.tsx
@@ -7,6 +7,7 @@ import { MasterToken, TokenProvider } from "@/common/providers/TokenProvider";
 import { Address } from "viem";
 import { fetchTokenData } from "@/common/lib/utils/fetchTokenData";
 import { fetchClankerByAddress } from "@/common/data/queries/clanker";
+import { fetchEmpireByAddress } from "@/common/data/queries/empireBuilder";
 import { EtherScanChainName } from "@/constants/etherscanChainIds";
 import ContractPrimarySpaceContent from "../../ContractPrimarySpaceContent";
 
@@ -15,22 +16,29 @@ async function loadTokenData(
   network: EtherScanChainName
 ): Promise<MasterToken> {
   if (network === "base") {
-    const [tokenResponse, clankerResponse] = await Promise.all([
-      fetchTokenData(contractAddress, null, network),
-      fetchClankerByAddress(contractAddress),
-    ]);
+    const [tokenResponse, clankerResponse, empireResponse] =
+      await Promise.all([
+        fetchTokenData(contractAddress, null, network),
+        fetchClankerByAddress(contractAddress),
+        fetchEmpireByAddress(contractAddress),
+      ]);
 
     return {
       network,
       geckoData: tokenResponse,
       clankerData: clankerResponse,
+      empireData: empireResponse,
     };
   } else {
-    const tokenResponse = await fetchTokenData(contractAddress, null, network);
+    const [tokenResponse, empireResponse] = await Promise.all([
+      fetchTokenData(contractAddress, null, network),
+      fetchEmpireByAddress(contractAddress),
+    ]);
     return {
       network,
       geckoData: tokenResponse,
       clankerData: null,
+      empireData: empireResponse,
     };
   }
 }

--- a/src/app/(spaces)/t/[network]/[contractAddress]/layout.tsx
+++ b/src/app/(spaces)/t/[network]/[contractAddress]/layout.tsx
@@ -5,6 +5,7 @@ import { fetchTokenData } from "@/common/lib/utils/fetchTokenData";
 import { getTokenMetadataStructure } from "@/common/lib/utils/tokenMetadata";
 import { defaultFrame } from "@/common/lib/frames/metadata";
 import { fetchClankerByAddress } from "@/common/data/queries/clanker";
+import { fetchEmpireByAddress } from "@/common/data/queries/empireBuilder";
 import { Address } from "viem";
 
 // Default metadata (used as fallback)
@@ -33,16 +34,18 @@ export async function generateMetadata({
   
   try {
     // Replace Promise.all with Promise.allSettled for more resilient error handling
-    const [tokenResult, clankerResult] = await Promise.allSettled([
+    const [tokenResult, clankerResult, empireResult] = await Promise.allSettled([
       fetchTokenData(contractAddress, null, network as string),
       fetchClankerByAddress(contractAddress as Address),
+      fetchEmpireByAddress(contractAddress as Address),
     ]);
-    
+
     const tokenData = tokenResult.status === 'fulfilled' ? tokenResult.value : null;
     const clankerData = clankerResult.status === 'fulfilled' ? clankerResult.value : null;
+    const empireData = empireResult.status === 'fulfilled' ? empireResult.value : null;
 
-    symbol = clankerData?.symbol || tokenData?.symbol || "";
-    name = clankerData?.name || tokenData?.name || "";
+    symbol = clankerData?.symbol || empireData?.token_symbol || tokenData?.symbol || "";
+    name = clankerData?.name || empireData?.token_name || tokenData?.name || "";
     imageUrl =
       clankerData?.img_url ||
       (tokenData?.image_url !== "missing.png" ? tokenData?.image_url || "" : "");

--- a/src/common/components/molecules/ClaimButtonWithModal.tsx
+++ b/src/common/components/molecules/ClaimButtonWithModal.tsx
@@ -20,7 +20,10 @@ const ClaimButtonWithModal: React.FC<ClaimButtonWithModalProps> = ({
   const [isModalOpen, setModalOpenState] = React.useState(false);
   const { tokenData } = useToken();
   const symbol =
-    tokenData?.clankerData?.symbol || tokenData?.geckoData?.symbol || "";
+    tokenData?.clankerData?.symbol ||
+    tokenData?.empireData?.token_symbol ||
+    tokenData?.geckoData?.symbol ||
+    "";
 
   const handleClaimClick = () => {
     setModalOpenState(true);

--- a/src/common/components/organisms/TokenDataHeader.tsx
+++ b/src/common/components/organisms/TokenDataHeader.tsx
@@ -6,11 +6,20 @@ import { useToken } from "@/common/providers/TokenProvider";
 
 const TokenDataHeader: React.FC = () => {
   const { tokenData } = useToken();
-  const contractAddress = tokenData?.clankerData?.contract_address || "";
+  const contractAddress =
+    tokenData?.clankerData?.contract_address ||
+    tokenData?.empireData?.base_token ||
+    "";
   const name =
-    tokenData?.clankerData?.name || tokenData?.geckoData?.name || "Loading...";
+    tokenData?.clankerData?.name ||
+    tokenData?.empireData?.token_name ||
+    tokenData?.geckoData?.name ||
+    "Loading...";
   const symbol =
-    tokenData?.clankerData?.symbol || tokenData?.geckoData?.symbol || "";
+    tokenData?.clankerData?.symbol ||
+    tokenData?.empireData?.token_symbol ||
+    tokenData?.geckoData?.symbol ||
+    "";
   const image =
     tokenData?.clankerData?.img_url ||
     (tokenData?.geckoData?.image_url !== "missing.png"

--- a/src/common/lib/utils/generateContractMetadataHtml.tsx
+++ b/src/common/lib/utils/generateContractMetadataHtml.tsx
@@ -18,7 +18,10 @@ export const generateContractMetadataHtml = (
     : "";
 
   const symbol =
-    tokenData?.clankerData?.symbol || tokenData?.geckoData?.symbol || "";
+    tokenData?.clankerData?.symbol ||
+    tokenData?.empireData?.token_symbol ||
+    tokenData?.geckoData?.symbol ||
+    "";
 
   const title = `${symbol}${priceInfo}`;
 

--- a/src/common/providers/TokenProvider.tsx
+++ b/src/common/providers/TokenProvider.tsx
@@ -13,11 +13,13 @@ import {
   GeckoTokenAttribute,
 } from "../lib/utils/fetchTokenData";
 import { ClankerToken } from "../data/queries/clanker";
+import { EmpireToken } from "../data/queries/empireBuilder";
 import { EtherScanChainName } from "@/constants/etherscanChainIds";
 
 export interface MasterToken {
   geckoData: GeckoTokenAttribute | null;
   clankerData: ClankerToken | null;
+  empireData: EmpireToken | null;
   network: EtherScanChainName;
 }
 
@@ -51,10 +53,17 @@ export const fetchMasterToken = async (
       `/api/clanker/ca?address=${address}`,
     ).then((res) => res.json());
 
+    const empireResponse = await fetch(
+      `/api/empire/ca?address=${address}`,
+    )
+      .then((res) => res.json())
+      .catch(() => null);
+
     return {
       network: network,
       geckoData: tokenResponse,
       clankerData: clankerResponse,
+      empireData: empireResponse,
     };
 };
 

--- a/src/pages/api/empire/ca.ts
+++ b/src/pages/api/empire/ca.ts
@@ -1,0 +1,26 @@
+import { fetchEmpireByAddress } from "@/common/data/queries/empireBuilder";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { Address } from "viem";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).end("Method Not Allowed");
+  }
+
+  const { address } = req.query;
+
+  if (!address) {
+    return res.status(400).json({ error: "Address is required" });
+  }
+
+  try {
+    const data = await fetchEmpireByAddress(address as Address);
+    return res.status(200).json(data);
+  } catch (_error) {
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+}


### PR DESCRIPTION
## Summary
- include Empire token information in MasterToken and token fetching
- add API endpoint and server-side loading for Empire token lookup
- display Empire token name/symbol across token pages and initial space configs

## Testing
- `npm run lint`
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_68c0990298548325831c82f8a84880b4