### PR TITLE
Simplify space editability check

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -145,9 +145,6 @@ export default function PublicSpace({
     });
   }, [currentIdentityPublicKey, spaceIdentityPublicKey]);
 
-  // Internal isEditable function
-  const isEditable = useCallback(() => editabilityCheck.isEditable, [editabilityCheck]);
-
   // Determine the page type if not explicitly provided
   const resolvedPageType = useMemo(() => {
     if (pageType) return pageType;
@@ -359,7 +356,7 @@ export default function PublicSpace({
     ...(currentConfig?.tabs[getCurrentTabName() ?? "Profile"]
       ? currentConfig.tabs[getCurrentTabName() ?? "Profile"]
       : { ...initialConfig }),
-    isEditable,
+    isEditable: editabilityCheck.isEditable,
   };
 
   const memoizedConfig = useMemo(() => {

--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -112,7 +112,8 @@ export default function PublicSpace({
   const [currentUserFid, setCurrentUserFid] = useState<number | null>(null);
   const [isSignedIntoFarcaster, setIsSignedIntoFarcaster] = useState(false);
 
-  const [spaceIdentityPublicKey, setSpaceIdentityPublicKey] = useState<string | null | undefined>(initialSpaceIdentityPublicKey);
+  const [spaceIdentityPublicKey, setSpaceIdentityPublicKey] =
+    useState<string | null | undefined>(initialSpaceIdentityPublicKey);
   const currentIdentityPublicKey = useCurrentSpaceIdentityPublicKey();
 
   useEffect(() => {

--- a/src/app/(spaces)/p/[proposalId]/ProposalDefinedSpace.tsx
+++ b/src/app/(spaces)/p/[proposalId]/ProposalDefinedSpace.tsx
@@ -43,8 +43,6 @@ const ProposalDefinedSpace = ({
         initialConfig={INITIAL_SPACE_CONFIG}
         getSpacePageUrl={getSpacePageUrl}
         isTokenPage={false}
-        spaceOwnerFid={1}
-        spaceOwnerAddress={ownerId}
         pageType="proposal"
       />
     </div>

--- a/src/app/(spaces)/s/[handle]/ProfileSpace.tsx
+++ b/src/app/(spaces)/s/[handle]/ProfileSpace.tsx
@@ -11,6 +11,7 @@ export type UserDefinedSpacePageProps = {
   spaceOwnerUsername: string | null;
   spaceId: string | null;
   tabName: string | string[] | null | undefined;
+  spaceIdentityPublicKey: string | null;
 };
 
 export const ProfileSpace = ({
@@ -18,6 +19,7 @@ export const ProfileSpace = ({
   spaceOwnerUsername,
   spaceId,
   tabName,
+  spaceIdentityPublicKey,
 }: UserDefinedSpacePageProps) => {
   if (isNil(spaceOwnerFid)) {
     return <SpaceNotFound />;
@@ -40,6 +42,7 @@ export const ProfileSpace = ({
       initialConfig={INITIAL_PERSONAL_SPACE_CONFIG}
       getSpacePageUrl={getSpacePageUrl}
       spaceOwnerFid={spaceOwnerFid}
+      spaceIdentityPublicKey={spaceIdentityPublicKey}
     />
   );
 };

--- a/src/app/(spaces)/s/[handle]/page.tsx
+++ b/src/app/(spaces)/s/[handle]/page.tsx
@@ -21,21 +21,23 @@ const loadUserSpaceData = async (
       spaceOwnerUsername: null,
       spaceId: null,
       tabName: null,
+      spaceIdentityPublicKey: null,
     };
   }
 
   const tabList = await getTabList(spaceOwnerFid);
 
   if (!tabList || tabList.length === 0) {
-    return { spaceOwnerFid, spaceOwnerUsername, spaceId: null, tabName: null };
+    return { spaceOwnerFid, spaceOwnerUsername, spaceId: null, tabName: null, spaceIdentityPublicKey: null };
   }
 
   const defaultTab: Tab = tabList[0];
 
   const spaceId = defaultTab.spaceId;
   const tabName = tabNameParam || defaultTab.spaceName;
+  const spaceIdentityPublicKey = defaultTab.identityPublicKey;
 
-  return { spaceOwnerFid, spaceOwnerUsername, spaceId, tabName };
+  return { spaceOwnerFid, spaceOwnerUsername, spaceId, tabName, spaceIdentityPublicKey };
 };
 
 const ProfileSpacePage = async ({
@@ -54,7 +56,7 @@ const ProfileSpacePage = async ({
     decodedTabNameParam = decodeURIComponent(tabNameParam);
   }
 
-  const { spaceOwnerFid, spaceOwnerUsername, spaceId, tabName } =
+  const { spaceOwnerFid, spaceOwnerUsername, spaceId, tabName, spaceIdentityPublicKey } =
     await loadUserSpaceData(handle, decodedTabNameParam);
 
   return (
@@ -63,6 +65,7 @@ const ProfileSpacePage = async ({
       spaceOwnerUsername={spaceOwnerUsername}
       spaceId={spaceId}
       tabName={tabName}
+      spaceIdentityPublicKey={spaceIdentityPublicKey}
     />
   );
 };

--- a/src/app/(spaces)/s/[handle]/utils.ts
+++ b/src/app/(spaces)/s/[handle]/utils.ts
@@ -5,6 +5,7 @@ import neynar from "@/common/data/api/neynar";
 export type Tab = {
   spaceId: string;
   spaceName: string;
+  identityPublicKey: string;
 };
 
 export const getUserMetadata = async (
@@ -32,7 +33,7 @@ export const getTabList = async (fid: number): Promise<Tab[]> => {
     // Add timestamp to bust cache
     const { data: registrations, error: regError } = await createSupabaseServerClient()
       .from("spaceRegistrations")
-      .select('spaceId, spaceName, fid')
+      .select('spaceId, spaceName, fid, identityPublicKey')
       .eq('fid', fid)
       .limit(1)
     

--- a/src/app/(spaces)/t/[network]/ContractDefinedSpace.tsx
+++ b/src/app/(spaces)/t/[network]/ContractDefinedSpace.tsx
@@ -11,6 +11,7 @@ export interface ContractDefinedSpaceProps {
   pinnedCastId?: string
   ownerId: string | number | null
   ownerIdType: OwnerType
+  spaceIdentityPublicKey: string | null
 }
 
 const ContractDefinedSpace = (props: ContractDefinedSpaceProps) => {

--- a/src/app/(spaces)/t/[network]/ContractPrimarySpaceContent.tsx
+++ b/src/app/(spaces)/t/[network]/ContractPrimarySpaceContent.tsx
@@ -18,6 +18,7 @@ const ContractPrimarySpaceContent: React.FC<ContractSpacePageProps> = ({
   contractAddress,
   owningIdentities,
   network,
+  spaceIdentityPublicKey,
 }) => {
   const [spaceId, setSpaceId] = useState(initialSpaceId);
   const [isLoading, setIsLoading] = useState(true);
@@ -86,6 +87,7 @@ const ContractPrimarySpaceContent: React.FC<ContractSpacePageProps> = ({
         spaceId={spaceId}
         tabName={isArray(tabName) ? tabName[0] : tabName ?? "Profile"}
         contractAddress={contractAddress}
+        spaceIdentityPublicKey={spaceIdentityPublicKey}
       />
     </>
   );

--- a/src/app/(spaces)/t/[network]/DesktopContractDefinedSpace.tsx
+++ b/src/app/(spaces)/t/[network]/DesktopContractDefinedSpace.tsx
@@ -6,7 +6,6 @@ import { useAuthenticatorManager } from "@/authenticators/AuthenticatorManager";
 import PublicSpace from "@/app/(spaces)/PublicSpace";
 import { ContractDefinedSpaceProps } from "./ContractDefinedSpace";
 import createInitialContractSpaceConfigForAddress from "@/constants/initialContractSpace";
-import { Address } from 'viem';
 
 const FARCASTER_NOUNSPACE_AUTHENTICATOR_NAME = "farcaster:nounspace";
 
@@ -14,8 +13,9 @@ export default function DesktopContractDefinedSpace({
   spaceId,
   tabName,
   contractAddress,
-  ownerId,
-  ownerIdType,
+  ownerId: _ownerId,
+  ownerIdType: _ownerIdType,
+  spaceIdentityPublicKey,
 }: ContractDefinedSpaceProps) {
   const { tokenData } = useToken();
   const [currentUserFid, setCurrentUserFid] = useState<number | null>(null);
@@ -67,10 +67,6 @@ export default function DesktopContractDefinedSpace({
     });
   }, [isSignedIntoFarcaster, authManagerLastUpdatedAt]);
 
-  // Convert ownerId to the appropriate type based on ownerIdType
-  const spaceOwnerFid = ownerIdType === 'fid' ? Number(ownerId) : undefined;
-  const spaceOwnerAddress = ownerIdType === 'address' ? ownerId as Address : undefined;
-
   return (
     <PublicSpace
       spaceId={spaceId}
@@ -79,9 +75,8 @@ export default function DesktopContractDefinedSpace({
       getSpacePageUrl={getSpacePageUrl}
       isTokenPage={true}
       contractAddress={contractAddress}
-      spaceOwnerFid={spaceOwnerFid}
-      spaceOwnerAddress={spaceOwnerAddress}
       tokenData={tokenData || undefined}
+      spaceIdentityPublicKey={spaceIdentityPublicKey}
     />
   );
 }

--- a/src/app/(spaces)/t/[network]/[contractAddress]/page.tsx
+++ b/src/app/(spaces)/t/[network]/[contractAddress]/page.tsx
@@ -16,6 +16,7 @@ export interface ContractSpacePageProps {
   ownerId: string | null;
   tokenData?: MasterToken;
   network: EtherScanChainName;
+  spaceIdentityPublicKey: string | null;
 }
 
 export default async function ContractPrimarySpace({ params }) {
@@ -28,6 +29,7 @@ export default async function ContractPrimarySpace({ params }) {
       ownerIdType,
       contractAddress,
       owningIdentities,
+      spaceIdentityPublicKey,
     },
   } = await loadContractData(resolvedParams || {});
   const network = resolvedParams?.network as EtherScanChainName;
@@ -45,6 +47,7 @@ export default async function ContractPrimarySpace({ params }) {
         contractAddress={contractAddress}
         owningIdentities={owningIdentities}
         network={network}
+        spaceIdentityPublicKey={spaceIdentityPublicKey}
       />
     </TokenProvider>
   );

--- a/src/common/data/loaders/contractPagePropsLoader.ts
+++ b/src/common/data/loaders/contractPagePropsLoader.ts
@@ -118,7 +118,7 @@ export async function loadContractData(
 
   let query = createSupabaseServerClient()
     .from("spaceRegistrations")
-    .select("spaceId, spaceName, contractAddress, network")
+    .select("spaceId, spaceName, contractAddress, network, identityPublicKey")
     .eq("contractAddress", contractAddress);
 
   if (isString(network)) {
@@ -139,6 +139,7 @@ export async function loadContractData(
   // });
 
   const spaceId = data?.[0]?.spaceId || null;
+  const spaceIdentityPublicKey = data?.[0]?.identityPublicKey || null;
 
   return {
     props: {
@@ -149,6 +150,7 @@ export async function loadContractData(
       contractAddress,
       pinnedCastId,
       owningIdentities,
+      spaceIdentityPublicKey,
     },
   };
 }

--- a/src/common/data/loaders/contractPagePropsLoader.ts
+++ b/src/common/data/loaders/contractPagePropsLoader.ts
@@ -21,6 +21,7 @@ const defaultContractPageProps = {
   contractAddress: null,
   owningIdentities: [],
   network: string,
+  spaceIdentityPublicKey: null,
 };
 
 export async function loadContractData(

--- a/src/common/utils/spaceEditability.ts
+++ b/src/common/utils/spaceEditability.ts
@@ -21,7 +21,9 @@ export const createEditabilityChecker = (
   context: EditabilityContext,
 ): EditabilityCheck => {
   const normalizeKey = (key?: string | null) =>
-    typeof key === "string" && key.length > 0 ? key.toLowerCase() : null;
+    typeof key === "string" && key.length > 0
+      ? key.replace(/^0x/i, "").toLowerCase()
+      : null;
 
   const currentKey = normalizeKey(context.currentIdentityPublicKey);
   const spaceKey = normalizeKey(context.spaceIdentityPublicKey);

--- a/src/common/utils/spaceEditability.ts
+++ b/src/common/utils/spaceEditability.ts
@@ -20,18 +20,18 @@ export type EditabilityContext = {
 export const createEditabilityChecker = (
   context: EditabilityContext,
 ): EditabilityCheck => {
-  const { currentIdentityPublicKey, spaceIdentityPublicKey } = context;
+  const normalizeKey = (key?: string | null) =>
+    typeof key === "string" && key.length > 0 ? key.toLowerCase() : null;
 
-  if (!currentIdentityPublicKey) {
-    return { isEditable: false, isLoading: false };
-  }
+  const currentKey = normalizeKey(context.currentIdentityPublicKey);
+  const spaceKey = normalizeKey(context.spaceIdentityPublicKey);
 
-  if (!spaceIdentityPublicKey) {
+  if (!currentKey || !spaceKey) {
     return { isEditable: false, isLoading: false };
   }
 
   return {
-    isEditable: currentIdentityPublicKey === spaceIdentityPublicKey,
+    isEditable: currentKey === spaceKey,
     isLoading: false,
   };
 };

--- a/src/common/utils/spaceEditability.ts
+++ b/src/common/utils/spaceEditability.ts
@@ -21,8 +21,11 @@ export const createEditabilityChecker = (
   context: EditabilityContext,
 ): EditabilityCheck => {
   const normalizeKey = (key?: string | null) =>
-    typeof key === "string" && key.length > 0
-      ? key.replace(/^0x/i, "").toLowerCase()
+    typeof key === "string" && key.trim().length > 0
+      ? key
+          .trim()
+          .replace(/^0x/i, "")
+          .toLowerCase()
       : null;
 
   const currentKey = normalizeKey(context.currentIdentityPublicKey);

--- a/src/common/utils/spaceEditability.ts
+++ b/src/common/utils/spaceEditability.ts
@@ -1,107 +1,37 @@
-import { isNil } from 'lodash';
-import { Address } from 'viem';
-import { MasterToken } from '@/common/providers/TokenProvider';
-
 export type EditabilityCheck = {
   isEditable: boolean;
   isLoading: boolean;
 };
 
 export type EditabilityContext = {
-  currentUserFid: number | null;
-  // Profile ownership
-  spaceOwnerFid?: number;
-  // Contract ownership
-  spaceOwnerAddress?: Address;
-  // Token-specific data
-  tokenData?: MasterToken;
-  // User's wallets for address ownership checks
-  wallets?: { address: Address }[];
-  // Space type
-  isTokenPage?: boolean;
+  /** Public key of the identity currently being used by the viewer */
+  currentIdentityPublicKey?: string | null;
+  /** Public key recorded for the space being viewed */
+  spaceIdentityPublicKey?: string | null;
 };
 
-export const createEditabilityChecker = (context: EditabilityContext) => {
-  const {
-    currentUserFid,
-    spaceOwnerFid,
-    spaceOwnerAddress,
-    tokenData,
-    wallets = [],
-    isTokenPage = false,
-  } = context;
+/**
+ * Determine whether the current viewer can customise the space.
+ *
+ * A space is editable only when the viewer's identity matches the
+ * identity recorded for the space. Unregistered spaces will simply
+ * return `isEditable: false`.
+ */
+export const createEditabilityChecker = (
+  context: EditabilityContext,
+): EditabilityCheck => {
+  const { currentIdentityPublicKey, spaceIdentityPublicKey } = context;
 
-  // console.log('Editability check context:', {
-  //   currentUserFid,
-  //   spaceOwnerFid,
-  //   spaceOwnerAddress,
-  //   tokenData: tokenData ? {
-  //     hasClankerData: !!tokenData.clankerData,
-  //     requestorFid: tokenData.clankerData?.requestor_fid,
-  //   } : null,
-  //   walletAddresses: wallets.map(w => w.address),
-  //   isTokenPage,
-  // });
-
-  // If we don't have a current user FID, we're definitely not editable
-  if (isNil(currentUserFid)) {
-    // console.log('Not editable: No current user FID');
+  if (!currentIdentityPublicKey) {
     return { isEditable: false, isLoading: false };
   }
 
-  // For token spaces, check requestor and ownership
-  if (isTokenPage) {
-    // console.log('Checking token space editability');
-    
-    // Check if user is the owner by FID first (doesn't require clankerData)
-    if (spaceOwnerFid && currentUserFid === spaceOwnerFid) {
-      // console.log('Editable: User owns by FID', {
-      //   currentUserFid,
-      //   spaceOwnerFid,
-      // });
-      return { isEditable: true, isLoading: false };
-    }
-
-    // Check if user owns the wallet address (doesn't require clankerData)
-    if (spaceOwnerAddress && wallets.some(w => w.address === spaceOwnerAddress)) {
-      // console.log('Editable: User owns by address', {
-      //   spaceOwnerAddress,
-      //   matchingWallet: wallets.find(w => w.address === spaceOwnerAddress),
-      // });
-      return { isEditable: true, isLoading: false };
-    }
-
-    // Only check requestor status if we have clankerData
-    if (tokenData && !isNil(tokenData.clankerData)) {
-      const requestorFid = tokenData.clankerData?.requestor_fid;
-      if (requestorFid && currentUserFid === Number(requestorFid)) {
-        // console.log('Editable: User is the requestor', {
-        //   currentUserFid,
-        //   requestorFid: Number(requestorFid),
-        // });
-        return { isEditable: true, isLoading: false };
-      }
-    } else {
-      // console.log('Skipping requestor check: No clankerData available');
-    }
-
-    // console.log('Not editable: No matching ownership conditions met for token space');
-  } else {
-    // For profile spaces, just check FID match
-    // console.log('Checking profile space editability');
-    if (spaceOwnerFid && currentUserFid === spaceOwnerFid) {
-      // console.log('Editable: User owns profile space', {
-      //   currentUserFid,
-      //   spaceOwnerFid,
-      // });
-      return { isEditable: true, isLoading: false };
-    }
-    // console.log('Not editable: FIDs do not match for profile space', {
-    //   currentUserFid,
-    //   spaceOwnerFid,
-    // });
+  if (!spaceIdentityPublicKey) {
+    return { isEditable: false, isLoading: false };
   }
 
-  // console.log('Final result: Not editable');
-  return { isEditable: false, isLoading: false };
-}; 
+  return {
+    isEditable: currentIdentityPublicKey === spaceIdentityPublicKey,
+    isLoading: false,
+  };
+};

--- a/tests/spaceEditability.test.ts
+++ b/tests/spaceEditability.test.ts
@@ -11,6 +11,14 @@ describe('createEditabilityChecker', () => {
     expect(result.isLoading).toBe(false);
   });
 
+  it('treats key comparison as case-insensitive', () => {
+    const result = createEditabilityChecker({
+      currentIdentityPublicKey: 'ABC',
+      spaceIdentityPublicKey: 'abc',
+    });
+    expect(result.isEditable).toBe(true);
+  });
+
   it('returns not editable when keys differ', () => {
     const result = createEditabilityChecker({
       currentIdentityPublicKey: 'abc',

--- a/tests/spaceEditability.test.ts
+++ b/tests/spaceEditability.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { createEditabilityChecker } from '@/common/utils/spaceEditability';
+
+describe('createEditabilityChecker', () => {
+  it('returns editable when keys match', () => {
+    const result = createEditabilityChecker({
+      currentIdentityPublicKey: 'abc',
+      spaceIdentityPublicKey: 'abc',
+    });
+    expect(result.isEditable).toBe(true);
+    expect(result.isLoading).toBe(false);
+  });
+
+  it('returns not editable when keys differ', () => {
+    const result = createEditabilityChecker({
+      currentIdentityPublicKey: 'abc',
+      spaceIdentityPublicKey: 'def',
+    });
+    expect(result.isEditable).toBe(false);
+  });
+
+  it('handles unregistered spaces', () => {
+    const result = createEditabilityChecker({
+      currentIdentityPublicKey: 'abc',
+      spaceIdentityPublicKey: null,
+    });
+    expect(result.isEditable).toBe(false);
+  });
+});

--- a/tests/spaceEditability.test.ts
+++ b/tests/spaceEditability.test.ts
@@ -27,6 +27,14 @@ describe('createEditabilityChecker', () => {
     expect(result.isEditable).toBe(true);
   });
 
+  it('trims surrounding whitespace before comparing', () => {
+    const result = createEditabilityChecker({
+      currentIdentityPublicKey: ' abc ',
+      spaceIdentityPublicKey: '\tabc\n',
+    });
+    expect(result.isEditable).toBe(true);
+  });
+
   it('returns not editable when keys differ', () => {
     const result = createEditabilityChecker({
       currentIdentityPublicKey: 'abc',

--- a/tests/spaceEditability.test.ts
+++ b/tests/spaceEditability.test.ts
@@ -19,6 +19,14 @@ describe('createEditabilityChecker', () => {
     expect(result.isEditable).toBe(true);
   });
 
+  it('ignores leading 0x prefixes when comparing keys', () => {
+    const result = createEditabilityChecker({
+      currentIdentityPublicKey: '0xabc',
+      spaceIdentityPublicKey: 'abc',
+    });
+    expect(result.isEditable).toBe(true);
+  });
+
   it('returns not editable when keys differ', () => {
     const result = createEditabilityChecker({
       currentIdentityPublicKey: 'abc',


### PR DESCRIPTION
## Summary
- use `identityPublicKey` from `spaceRegistrations` to determine space editability
- plumb identity public keys through profile and contract loaders
- add unit test for `createEditabilityChecker`

## Testing
- `npx vitest tests/spaceEditability.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c0989d8e808325a639affdb9136426