### PR TITLE
Normalize wallet key comparison

### DIFF
--- a/src/common/utils/spaceEditability.ts
+++ b/src/common/utils/spaceEditability.ts
@@ -2,6 +2,11 @@ import { isNil } from 'lodash';
 import { Address } from 'viem';
 import { MasterToken } from '@/common/providers/TokenProvider';
 
+// Normalize wallet keys for comparison
+// - Lowercase the key
+// - Strip a leading `0x` if present
+export const normalizeKey = (key: string) => key.replace(/^0x/i, '').toLowerCase();
+
 export type EditabilityCheck = {
   isEditable: boolean;
   isLoading: boolean;
@@ -63,7 +68,10 @@ export const createEditabilityChecker = (context: EditabilityContext) => {
     }
 
     // Check if user owns the wallet address (doesn't require clankerData)
-    if (spaceOwnerAddress && wallets.some(w => w.address === spaceOwnerAddress)) {
+    if (
+      spaceOwnerAddress &&
+      wallets.some(w => normalizeKey(w.address) === normalizeKey(spaceOwnerAddress))
+    ) {
       // console.log('Editable: User owns by address', {
       //   spaceOwnerAddress,
       //   matchingWallet: wallets.find(w => w.address === spaceOwnerAddress),

--- a/tests/spaceEditability.test.ts
+++ b/tests/spaceEditability.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { createEditabilityChecker } from '../src/common/utils/spaceEditability';
+import type { Address } from 'viem';
+
+describe('space editability', () => {
+  it('handles keys with and without 0x prefix', () => {
+    const context = {
+      currentUserFid: 1,
+      spaceOwnerAddress: 'abcdef' as unknown as Address,
+      wallets: [{ address: '0xABCDEF' as Address }],
+      isTokenPage: true,
+    };
+
+    const result = createEditabilityChecker(context);
+    expect(result.isEditable).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `normalizeKey` helper that removes optional `0x` prefix before lowercasing
- Use normalized keys when checking wallet ownership
- Test that editability accepts keys with and without `0x`

## Testing
- `npm run lint`
- `npm run check-types`
- `npx vitest tests/spaceEditability.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c2e6df39b0832599bf2cd8171a1e9b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token-space edit permissions by normalizing wallet addresses (case-insensitive, ignores optional 0x prefix). This prevents false mismatches and ensures rightful owners can edit their spaces regardless of address format, improving reliability across different wallet/display formats.

* **Tests**
  * Added unit tests verifying address normalization and editability when addresses include or omit the 0x prefix, increasing confidence in ownership checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->