### PR TITLE
Feature: Add Farcaster channel spaces

### DIFF
--- a/src/app/(spaces)/c/[channelId]/ChannelSpace.tsx
+++ b/src/app/(spaces)/c/[channelId]/ChannelSpace.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import React, { useMemo } from "react";
+import PublicSpace from "@/app/(spaces)/PublicSpace";
+import { ChannelSpacePageData } from "@/common/types/spaceData";
+import { useCurrentSpaceIdentityPublicKey } from "@/common/lib/hooks/useCurrentSpaceIdentityPublicKey";
+
+export interface ChannelSpaceProps {
+  spacePageData: Omit<ChannelSpacePageData, "isEditable" | "spacePageUrl">;
+  tabName: string;
+}
+
+const isChannelSpaceEditable = (
+  moderatorFids: number[],
+  currentUserFid: number | undefined,
+  spaceId: string | undefined,
+  spaceIdentityPublicKey?: string,
+  currentUserIdentityPublicKey?: string,
+) => {
+  const hasModeratorPrivileges =
+    currentUserFid !== undefined &&
+    moderatorFids.includes(currentUserFid);
+
+  const hasIdentityOwnership =
+    !!(
+      spaceId &&
+      spaceIdentityPublicKey &&
+      currentUserIdentityPublicKey &&
+      spaceIdentityPublicKey === currentUserIdentityPublicKey
+    );
+
+  return hasModeratorPrivileges || hasIdentityOwnership;
+};
+
+export default function ChannelSpace({ spacePageData, tabName }: ChannelSpaceProps) {
+  const currentUserIdentityPublicKey = useCurrentSpaceIdentityPublicKey();
+
+  const spaceDataWithClientLogic = useMemo(() => ({
+    ...spacePageData,
+    spacePageUrl: (tab: string) => `/c/${spacePageData.channelId}/${encodeURIComponent(tab)}`,
+    isEditable: (currentUserFid: number | undefined) =>
+      isChannelSpaceEditable(
+        spacePageData.moderatorFids,
+        currentUserFid,
+        spacePageData.spaceId,
+        spacePageData.identityPublicKey,
+        currentUserIdentityPublicKey,
+      ),
+  }), [spacePageData, currentUserIdentityPublicKey]);
+
+  return (
+    <PublicSpace
+      spacePageData={spaceDataWithClientLogic}
+      tabName={tabName}
+    />
+  );
+}

--- a/src/app/(spaces)/c/[channelId]/[tabName]/page.tsx
+++ b/src/app/(spaces)/c/[channelId]/[tabName]/page.tsx
@@ -1,0 +1,3 @@
+import ChannelSpacePage from "@/app/(spaces)/c/[channelId]/page";
+
+export default ChannelSpacePage;

--- a/src/app/(spaces)/c/[channelId]/layout.tsx
+++ b/src/app/(spaces)/c/[channelId]/layout.tsx
@@ -1,0 +1,55 @@
+import { WEBSITE_URL } from "@/constants/app";
+import type { Metadata } from "next/types";
+import { getChannelMetadata } from "./utils";
+
+const DEFAULT_METADATA: Metadata = {
+  title: "Channel | Nounspace",
+  description: "Explore Farcaster channel spaces on Nounspace.",
+  openGraph: {
+    title: "Channel | Nounspace",
+    description: "Explore Farcaster channel spaces on Nounspace.",
+    url: WEBSITE_URL,
+  },
+};
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ channelId: string; tabName?: string }>;
+}): Promise<Metadata> {
+  const { channelId, tabName } = await params;
+
+  if (!channelId) {
+    return DEFAULT_METADATA;
+  }
+
+  const channel = await getChannelMetadata(channelId);
+
+  if (!channel) {
+    return {
+      ...DEFAULT_METADATA,
+      title: `${channelId} | Nounspace`,
+    };
+  }
+
+  const name = channel.name || channel.id;
+  const description = channel.description || `Farcaster channel /${channel.id} on Nounspace.`;
+  const pageUrl = tabName
+    ? `${WEBSITE_URL}/c/${channel.id}/${encodeURIComponent(tabName)}`
+    : `${WEBSITE_URL}/c/${channel.id}`;
+
+  return {
+    title: `${name} | Nounspace`,
+    description,
+    openGraph: {
+      title: `${name} | Nounspace`,
+      description,
+      url: pageUrl,
+      images: channel.image_url ? [channel.image_url] : undefined,
+    },
+  };
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/(spaces)/c/[channelId]/page.tsx
+++ b/src/app/(spaces)/c/[channelId]/page.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import SpaceNotFound from "@/app/(spaces)/SpaceNotFound";
+import ChannelSpace from "./ChannelSpace";
+import { loadChannelSpaceData } from "./utils";
+
+interface ChannelSpacePageProps {
+  params: Promise<{
+    channelId: string;
+    tabName?: string;
+  }>;
+}
+
+const ChannelSpacePage = async ({ params }: ChannelSpacePageProps) => {
+  const { channelId, tabName: tabNameParam } = await params;
+
+  if (!channelId) {
+    return <SpaceNotFound />;
+  }
+
+  try {
+    const decodedTabName = tabNameParam ? decodeURIComponent(tabNameParam) : undefined;
+
+    const channelSpaceData = await loadChannelSpaceData(channelId, decodedTabName);
+
+    if (!channelSpaceData) {
+      return <SpaceNotFound />;
+    }
+
+    return (
+      <ChannelSpace
+        spacePageData={channelSpaceData}
+        tabName={decodedTabName || channelSpaceData.defaultTab}
+      />
+    );
+  } catch (error) {
+    console.error("Error loading channel space data:", error);
+    return <SpaceNotFound />;
+  }
+};
+
+export default ChannelSpacePage;

--- a/src/app/(spaces)/c/[channelId]/utils.ts
+++ b/src/app/(spaces)/c/[channelId]/utils.ts
@@ -1,0 +1,109 @@
+import { createSupabaseServerClient } from "@/common/data/database/supabase/clients/server";
+import neynar from "@/common/data/api/neynar";
+import { unstable_noStore as noStore } from "next/cache";
+import {
+  ChannelSpacePageData,
+  SPACE_TYPES,
+} from "@/common/types/spaceData";
+import createInitialChannelSpaceConfig from "@/constants/initialChannelSpace";
+import { Channel, ChannelType } from "@neynar/nodejs-sdk/build/api";
+
+export const getChannelMetadata = async (
+  channelId: string,
+): Promise<Channel | null> => {
+  try {
+    const { channel } = await neynar.lookupChannel({
+      id: channelId,
+      type: ChannelType.Id,
+    });
+    return channel;
+  } catch (error) {
+    console.error("Error fetching channel metadata:", error);
+    return null;
+  }
+};
+
+export const createChannelSpaceData = (
+  spaceId: string | undefined,
+  channelId: string,
+  channelDisplayName: string | undefined,
+  moderatorFids: number[],
+  tabName: string,
+  identityPublicKey?: string,
+): Omit<ChannelSpacePageData, "isEditable" | "spacePageUrl"> => {
+  const config = {
+    ...createInitialChannelSpaceConfig(channelId),
+    timestamp: new Date().toISOString(),
+  };
+
+  return {
+    spaceId,
+    spaceName: channelId,
+    spaceType: SPACE_TYPES.CHANNEL,
+    updatedAt: new Date().toISOString(),
+    defaultTab: "Channel",
+    currentTab: tabName,
+    config,
+    spaceOwnerFid: moderatorFids[0],
+    channelId,
+    channelDisplayName,
+    moderatorFids,
+    identityPublicKey,
+  };
+};
+
+export const loadChannelSpaceRegistration = async (
+  channelId: string,
+): Promise<{
+  spaceId?: string;
+  identityPublicKey?: string;
+  fid?: number | null;
+} | null> => {
+  noStore();
+  try {
+    const { data, error } = await createSupabaseServerClient()
+      .from("spaceRegistrations")
+      .select("spaceId, identityPublicKey, fid")
+      .eq("channelId", channelId)
+      .order("timestamp", { ascending: true })
+      .limit(1);
+
+    if (error) {
+      console.error("Error fetching channel space registration:", error);
+      return null;
+    }
+
+    return data && data.length > 0 ? data[0] : null;
+  } catch (error) {
+    console.error("Exception in loadChannelSpaceRegistration:", error);
+    return null;
+  }
+};
+
+export const loadChannelSpaceData = async (
+  channelId: string,
+  tabNameParam?: string,
+): Promise<Omit<ChannelSpacePageData, "isEditable" | "spacePageUrl"> | null> => {
+  noStore();
+
+  const channelMetadata = await getChannelMetadata(channelId);
+
+  if (!channelMetadata) {
+    return null;
+  }
+
+  const registration = await loadChannelSpaceRegistration(channelId);
+  const spaceId = registration?.spaceId;
+  const identityPublicKey = registration?.identityPublicKey;
+
+  const tabName = tabNameParam || "Channel";
+
+  return createChannelSpaceData(
+    spaceId,
+    channelId,
+    channelMetadata.name,
+    channelMetadata.moderator_fids || [],
+    tabName,
+    identityPublicKey,
+  );
+};

--- a/src/common/data/queries/farcaster.ts
+++ b/src/common/data/queries/farcaster.ts
@@ -1,9 +1,13 @@
 import {
   BulkUsersResponse,
+  ChannelMemberListResponse,
+  ChannelResponse,
   Conversation,
   FeedResponse,
   FeedType,
   FilterType,
+  FollowersResponse,
+  RelevantFollowersResponse,
 } from "@neynar/nodejs-sdk/build/api";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import axios from "axios";
@@ -179,5 +183,106 @@ export const useFidFromAddress = (address?: string) => {
       return undefined;
     },
     staleTime: 1000 * 60 * 2,
+  });
+};
+
+export const useChannelById = (channelId: string, viewerFid?: number) => {
+  return useQuery({
+    queryKey: ["channel", channelId, viewerFid],
+    enabled: !!channelId,
+    staleTime: 1000 * 60 * 3,
+    queryFn: async () => {
+      const params: Record<string, number | string> = { id: channelId };
+      if (typeof viewerFid === "number") {
+        params.viewer_fid = viewerFid;
+      }
+
+      const { data } = await axiosBackend.get<ChannelResponse>(
+        "/api/farcaster/neynar/channel",
+        {
+          params,
+        },
+      );
+
+      return data;
+    },
+  });
+};
+
+export const useChannelMembers = (channelId: string, limit = 10) => {
+  return useQuery({
+    queryKey: ["channel-members", channelId, limit],
+    enabled: !!channelId,
+    staleTime: 1000 * 60 * 3,
+    queryFn: async () => {
+      const params: Record<string, number | string> = {
+        channel_id: channelId,
+      };
+
+      if (typeof limit === "number") {
+        params.limit = limit;
+      }
+
+      const { data } = await axiosBackend.get<ChannelMemberListResponse>(
+        "/api/farcaster/neynar/channel/members",
+        {
+          params,
+        },
+      );
+
+      return data;
+    },
+  });
+};
+
+export const useChannelFollowers = (channelId: string, limit = 10) => {
+  return useQuery({
+    queryKey: ["channel-followers", channelId, limit],
+    enabled: !!channelId,
+    staleTime: 1000 * 60 * 3,
+    queryFn: async () => {
+      const params: Record<string, number | string> = {
+        id: channelId,
+      };
+
+      if (typeof limit === "number") {
+        params.limit = limit;
+      }
+
+      const { data } = await axiosBackend.get<FollowersResponse>(
+        "/api/farcaster/neynar/channel/followers",
+        {
+          params,
+        },
+      );
+
+      return data;
+    },
+  });
+};
+
+export const useChannelRelevantFollowers = (
+  channelId: string,
+  viewerFid?: number,
+) => {
+  return useQuery({
+    queryKey: ["channel-relevant-followers", channelId, viewerFid],
+    enabled: !!channelId && typeof viewerFid === "number",
+    staleTime: 1000 * 60 * 3,
+    queryFn: async () => {
+      const params: Record<string, number | string> = {
+        id: channelId,
+        viewer_fid: viewerFid!,
+      };
+
+      const { data } = await axiosBackend.get<RelevantFollowersResponse>(
+        "/api/farcaster/neynar/channel/relevant-followers",
+        {
+          params,
+        },
+      );
+
+      return data;
+    },
   });
 };

--- a/src/common/data/stores/app/space/spaceStore.ts
+++ b/src/common/data/stores/app/space/spaceStore.ts
@@ -8,12 +8,14 @@ import { EtherScanChainName } from "@/constants/etherscanChainIds";
 import { SPACE_TYPES } from "@/common/types/spaceData";
 import { INITIAL_SPACE_CONFIG_EMPTY } from "@/constants/initialSpaceConfig";
 import createIntialProfileSpaceConfigForFid from "@/constants/initialProfileSpace";
+import createInitialChannelSpaceConfig from "@/constants/initialChannelSpace";
 import {
   ModifiableSpacesResponse,
   RegisterNewSpaceResponse,
   SpaceRegistrationContract,
   SpaceRegistrationFid,
   SpaceRegistrationProposer,
+  SpaceRegistrationChannel,
 } from "@/pages/api/space/registry";
 import {
   UnsignedUpdateTabOrderRequest,
@@ -99,6 +101,7 @@ interface LocalSpace extends CachedSpace {
     [newName: string]: string;
   };
   fid?: number | null;
+  channelId?: string | null;
 }
 
 interface SpaceState {
@@ -167,6 +170,13 @@ interface SpaceActions {
   registerProposalSpace: (
     proposalId: string,
     initialConfig: Omit<SpaceConfig, "isEditable">,
+  ) => Promise<string | undefined>;
+  registerChannelSpace: (
+    channelId: string,
+    channelName: string,
+    moderatorFid: number,
+    path: string,
+    moderatorFids?: number[],
   ) => Promise<string | undefined>;
   clear: () => void;
 }
@@ -836,6 +846,119 @@ export const createSpaceStoreFunc = (
       throw e;
     }
   },
+  registerChannelSpace: async (
+    channelId,
+    channelName,
+    moderatorFid,
+    path,
+    moderatorFids,
+  ) => {
+    try {
+      const existingLocalSpace = Object.values(get().space.localSpaces).find(
+        (space) => space.channelId === channelId,
+      );
+
+      if (existingLocalSpace) {
+        return existingLocalSpace.id;
+      }
+
+      try {
+        const { data } = await axiosBackend.get(
+          "/api/space/registry",
+          {
+            params: { channelId },
+          },
+        );
+
+        const existingSpaceId = data?.value?.spaceId;
+
+        if (existingSpaceId) {
+          return existingSpaceId;
+        }
+      } catch (lookupError: any) {
+        if (lookupError?.response?.status !== 404) {
+          console.error("Error checking existing channel space:", lookupError);
+        }
+      }
+
+      const { data: modifiableSpaces } = await axiosBackend.get<ModifiableSpacesResponse>(
+        "/api/space/registry",
+        {
+          params: {
+            identityPublicKey: get().account.currentSpaceIdentityPublicKey,
+          },
+        },
+      );
+
+      if (modifiableSpaces.value) {
+        const existingSpace = modifiableSpaces.value.spaces.find(
+          (space) => space.channelId === channelId,
+        );
+
+        if (existingSpace) {
+          return existingSpace.spaceId;
+        }
+      }
+
+      if (moderatorFids && !moderatorFids.includes(moderatorFid)) {
+        console.warn(
+          "Attempted to register channel space with moderator FID not in moderators list",
+          { channelId, moderatorFid },
+        );
+      }
+
+      const unsignedRegistration: Omit<SpaceRegistrationChannel, "signature"> = {
+        identityPublicKey: get().account.currentSpaceIdentityPublicKey!,
+        spaceName: channelName || channelId,
+        timestamp: moment().toISOString(),
+        fid: moderatorFid,
+        channelId,
+        spaceType: SPACE_TYPES.CHANNEL,
+      };
+
+      const registration = signSignable(
+        unsignedRegistration,
+        get().account.getCurrentIdentity()!.rootKeys.privateKey,
+      );
+
+      const { data } = await axiosBackend.post<RegisterNewSpaceResponse>(
+        "/api/space/registry",
+        registration,
+      );
+
+      const newSpaceId = data.value!.spaceId;
+
+      set((draft) => {
+        draft.space.editableSpaces[newSpaceId] = channelName || channelId;
+        draft.space.localSpaces[newSpaceId] = {
+          id: newSpaceId,
+          updatedAt: moment().toISOString(),
+          tabs: {},
+          order: [],
+          changedNames: {},
+          fid: moderatorFid,
+          channelId,
+        };
+      });
+
+      await get().space.createSpaceTab(
+        newSpaceId,
+        "Channel",
+        createInitialChannelSpaceConfig(channelId),
+      );
+
+      analytics.track(AnalyticsEvent.SPACE_REGISTERED, {
+        type: "channel",
+        spaceId: newSpaceId,
+        path,
+      });
+
+      return newSpaceId;
+    } catch (error) {
+      console.error("Failed to register channel space:", error);
+      throw error;
+    }
+  },
   registerSpaceContract: async (
     address,
     name,
@@ -1120,20 +1243,21 @@ export const createSpaceStoreFunc = (
               // Only create entry if it doesn't exist or if it's missing contract metadata
               if (!draft.space.localSpaces[spaceInfo.spaceId] || 
                   (!draft.space.localSpaces[spaceInfo.spaceId].contractAddress && spaceInfo.contractAddress)) {
-                draft.space.localSpaces[spaceInfo.spaceId] = {
-                  id: spaceInfo.spaceId,
-                  updatedAt: moment().toISOString(),
-                  tabs: draft.space.localSpaces[spaceInfo.spaceId]?.tabs || {},
-                  order: draft.space.localSpaces[spaceInfo.spaceId]?.order || [],
-                  changedNames: draft.space.localSpaces[spaceInfo.spaceId]?.changedNames || {},
-                  contractAddress: spaceInfo.contractAddress,
-                  network: spaceInfo.network,
-                  fid: spaceInfo.fid,
-                  proposalId: spaceInfo.proposalId,
-                };
-              }
-            });
-          }
+              draft.space.localSpaces[spaceInfo.spaceId] = {
+                id: spaceInfo.spaceId,
+                updatedAt: moment().toISOString(),
+                tabs: draft.space.localSpaces[spaceInfo.spaceId]?.tabs || {},
+                order: draft.space.localSpaces[spaceInfo.spaceId]?.order || [],
+                changedNames: draft.space.localSpaces[spaceInfo.spaceId]?.changedNames || {},
+                contractAddress: spaceInfo.contractAddress,
+                network: spaceInfo.network,
+                fid: spaceInfo.fid,
+                proposalId: spaceInfo.proposalId,
+                channelId: spaceInfo.channelId,
+              };
+            }
+          });
+        }
         }, "loadEditableSpaces");
         return editableSpaces;
       }

--- a/src/common/lib/hooks/useSearchChannels.ts
+++ b/src/common/lib/hooks/useSearchChannels.ts
@@ -1,0 +1,76 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { debounce } from "lodash";
+import axios, { CancelTokenSource } from "axios";
+import axiosBackend from "@/common/data/api/backend";
+import { ChannelSearchResponse } from "@neynar/nodejs-sdk/build/api";
+
+type ChannelSearchResult = {
+  channels: ChannelSearchResponse["channels"];
+  cursor?: string | null;
+};
+
+export type ChannelSearchReturnValue = {
+  channels: ChannelSearchResponse["channels"];
+  loading: boolean;
+  error: string | null;
+};
+
+const useSearchChannels = (query: string | null, debounceMs: number = 300) => {
+  const [results, setResults] = useState<ChannelSearchResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const cancelRequest = useRef<CancelTokenSource | null>(null);
+
+  const fetchResults = useCallback(
+    debounce(async (q: string) => {
+      if (cancelRequest.current) {
+        cancelRequest.current.cancel("New channel search initiated");
+      }
+
+      cancelRequest.current = axios.CancelToken.source();
+
+      try {
+        const { data } = await axiosBackend.get<ChannelSearchResponse>(
+          "/api/farcaster/neynar/search-channels",
+          {
+            params: {
+              q,
+              limit: 5,
+            },
+            cancelToken: cancelRequest.current.token,
+          },
+        );
+
+        setResults({ channels: data.channels, cursor: data.next?.cursor });
+        setLoading(false);
+        setError(null);
+      } catch (err) {
+        if (axios.isCancel(err)) {
+          return;
+        }
+        setError("An error occurred while searching channels");
+        setLoading(false);
+      }
+    }, debounceMs),
+    [debounceMs],
+  );
+
+  useEffect(() => {
+    setError(null);
+    if (query && query.trim().length > 0) {
+      setLoading(true);
+      fetchResults(query.trim());
+    } else {
+      setLoading(false);
+      setResults(null);
+    }
+  }, [query, fetchResults]);
+
+  return {
+    channels: results?.channels ?? [],
+    loading,
+    error,
+  };
+};
+
+export default useSearchChannels;

--- a/src/common/types/spaceData.ts
+++ b/src/common/types/spaceData.ts
@@ -6,8 +6,9 @@ import { ProposalData } from '@/app/(spaces)/p/[proposalId]/utils';
 // Space type definitions - the single source of truth for space types
 export const SPACE_TYPES = {
   PROFILE: 'profile',
-  TOKEN: 'token', 
+  TOKEN: 'token',
   PROPOSAL: 'proposal',
+  CHANNEL: 'channel',
 } as const;
 
 // TypeScript type derived from the constants (for type checking)
@@ -60,8 +61,21 @@ export interface ProposalSpacePageData extends SpacePageData {
   identityPublicKey?: string;
 }
 
+export interface ChannelSpacePageData extends SpacePageData {
+  spaceType: typeof SPACE_TYPES.CHANNEL;
+  defaultTab: 'Channel';
+  channelId: string;
+  channelDisplayName?: string;
+  moderatorFids: number[];
+  identityPublicKey?: string;
+}
+
 // Union type for all spaces
-export type Space = ProfileSpacePageData | TokenSpacePageData | ProposalSpacePageData;
+export type Space =
+  | ProfileSpacePageData
+  | TokenSpacePageData
+  | ProposalSpacePageData
+  | ChannelSpacePageData;
 
 // Type guards (actual TypeScript type guards that narrow types)
 export function isProfileSpace(space: SpacePageData): space is ProfileSpacePageData {
@@ -74,5 +88,9 @@ export function isTokenSpace(space: SpacePageData): space is TokenSpacePageData 
 
 export function isProposalSpace(space: SpacePageData): space is ProposalSpacePageData {
   return space.spaceType === SPACE_TYPES.PROPOSAL;
+}
+
+export function isChannelSpace(space: SpacePageData): space is ChannelSpacePageData {
+  return space.spaceType === SPACE_TYPES.CHANNEL;
 }
 

--- a/src/constants/initialChannelSpace.ts
+++ b/src/constants/initialChannelSpace.ts
@@ -1,0 +1,55 @@
+import { SpaceConfig } from "@/app/(spaces)/Space";
+import { FilterType, FeedType } from "@neynar/nodejs-sdk/build/api";
+import { cloneDeep } from "lodash";
+import { getLayoutConfig } from "@/common/utils/layoutFormatUtils";
+import { INITIAL_SPACE_CONFIG_EMPTY } from "./initialSpaceConfig";
+
+const INITIAL_CHANNEL_SPACE_CONFIG = cloneDeep(INITIAL_SPACE_CONFIG_EMPTY);
+INITIAL_CHANNEL_SPACE_CONFIG.tabNames = ["Channel"];
+
+const createInitialChannelSpaceConfig = (
+  channelId: string,
+): Omit<SpaceConfig, "isEditable"> => {
+  const config = cloneDeep(INITIAL_CHANNEL_SPACE_CONFIG);
+
+  config.fidgetInstanceDatums = {
+    "feed:channel": {
+      config: {
+        editable: false,
+        settings: {
+          feedType: FeedType.Filter,
+          filterType: FilterType.ChannelId,
+          channel: channelId,
+        },
+        data: {},
+      },
+      fidgetType: "feed",
+      id: "feed:channel",
+    },
+  };
+
+  const layoutItems = [
+    {
+      w: 6,
+      h: 12,
+      x: 0,
+      y: 0,
+      i: "feed:channel",
+      minW: 4,
+      maxW: 36,
+      minH: 6,
+      maxH: 36,
+      moved: false,
+      static: false,
+    },
+  ];
+
+  const layoutConfig = getLayoutConfig(config.layoutDetails);
+  layoutConfig.layout = layoutItems;
+
+  config.tabNames = ["Channel"];
+
+  return config;
+};
+
+export default createInitialChannelSpaceConfig;

--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -23,6 +23,7 @@ import { ErrorBoundary } from "@sentry/react";
 import { Properties } from "csstype";
 import { get, includes, isObject, isUndefined, map } from "lodash";
 import Image from "next/image";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import React, { useCallback, useMemo, useState } from "react";
 import { FaReply } from "react-icons/fa6";
@@ -455,12 +456,14 @@ const CastReactions = ({ cast }: { cast: CastWithInteractions }) => {
 
         {renderReaction(CastReactionType.quote, true, undefined, getIconForCastReactionType(CastReactionType.quote))}
         {cast.channel && cast.channel.name && (
-          <div
+          <Link
             key={`cast-${cast.hash}-channel-name`}
-            className="mt-1.5 flex align-center text-sm opacity-40 py-1 px-1.5 rounded-md"
+            href={`/c/${encodeURIComponent((cast.channel.id || cast.channel.name).toString())}`}
+            className="mt-1.5 flex items-center text-sm opacity-60 transition-colors hover:text-blue-500 focus:text-blue-500 py-1 px-1.5 rounded-md"
+            onClick={(event) => event.stopPropagation()}
           >
             /{cast.channel.name}
-          </div>
+          </Link>
         )}
         <div
           className="ml-auto mt-1.5 flex cursor-pointer text-sm opacity-50 hover:text-foreground/85 hover:bg-background/85 py-1 px-1.5 rounded-md"

--- a/src/fidgets/index.ts
+++ b/src/fidgets/index.ts
@@ -5,6 +5,7 @@ import Gallery from "./ui/gallery";
 import TextFidget from "./ui/Text";
 import IFrame from "./ui/IFrame";
 import Profile from "./ui/profile";
+import Channel from "./ui/channel";
 import Grid from "./layout/Grid";
 import NounishGovernance from "./community/nouns-dao/NounishGovernance";
 import Cast from "./farcaster/Cast";
@@ -28,6 +29,7 @@ export const CompleteFidgets = {
     process.env.NEXT_PUBLIC_VERCEL_ENV === "development" ? Example : undefined,
   profile:
     process.env.NEXT_PUBLIC_VERCEL_ENV === "development" ? Profile : undefined,
+  channel: Channel,
   // Farcaster
   frame: Frame,
   // iframely: iframely,

--- a/src/fidgets/ui/channel.tsx
+++ b/src/fidgets/ui/channel.tsx
@@ -1,0 +1,284 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/common/components/atoms/avatar";
+import TextInput from "@/common/components/molecules/TextInput";
+import {
+  useChannelById,
+  useChannelFollowers,
+  useChannelMembers,
+  useChannelRelevantFollowers,
+} from "@/common/data/queries/farcaster";
+import { FidgetArgs, FidgetModule, FidgetProperties } from "@/common/fidgets";
+import { useFarcasterSigner } from "@/fidgets/farcaster";
+import { defaultStyleFields } from "@/fidgets/helpers";
+import clsx from "clsx";
+import { first, take } from "lodash";
+import React, { useMemo } from "react";
+
+export type ChannelFidgetSettings = {
+  channelId: string;
+};
+
+const channelProperties: FidgetProperties = {
+  fidgetName: "Channel",
+  icon: 0x1f4f0,
+  mobileIcon: undefined,
+  fields: [
+    {
+      fieldName: "channelId",
+      displayName: "Channel",
+      displayNameHint: "Enter the Farcaster channel ID (without the leading slash).",
+      default: "",
+      required: true,
+      inputSelector: TextInput,
+    },
+    ...defaultStyleFields,
+  ],
+  size: {
+    minHeight: 4,
+    maxHeight: 36,
+    minWidth: 4,
+    maxWidth: 36,
+  },
+};
+
+const SkeletonSection: React.FC = () => (
+  <div className="flex flex-col gap-4 animate-pulse">
+    <div className="flex items-center gap-4">
+      <div className="h-16 w-16 rounded-full bg-gray-200 dark:bg-gray-700" />
+      <div className="flex flex-col gap-2 flex-1">
+        <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
+        <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-1/2" />
+      </div>
+    </div>
+    <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-full" />
+    <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-3/4" />
+  </div>
+);
+
+const SectionHeading: React.FC<{ title: string; count?: number }> = ({
+  title,
+  count,
+}) => (
+  <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+    <span>{title}</span>
+    {typeof count === "number" && (
+      <span className="text-slate-600 dark:text-slate-300">{count.toLocaleString()}</span>
+    )}
+  </div>
+);
+
+type SimpleUser = {
+  fid?: number;
+  username?: string;
+  display_name?: string;
+  pfp_url?: string;
+};
+
+const toSimpleUser = (
+  user?: {
+    fid?: number;
+    username?: string;
+    display_name?: string;
+    pfp_url?: string;
+  } | null,
+): SimpleUser | undefined => {
+  if (!user) {
+    return undefined;
+  }
+
+  const { fid, username, display_name, pfp_url } = user;
+
+  return {
+    fid,
+    username,
+    display_name,
+    pfp_url,
+  };
+};
+
+const InlineAvatarList: React.FC<{
+  users: (SimpleUser | undefined)[];
+  limit?: number;
+}> = ({ users, limit = 6 }) => {
+  const visibleUsers = useMemo(
+    () => take(users.filter((user): user is SimpleUser => Boolean(user)), limit),
+    [users, limit],
+  );
+
+  if (!visibleUsers.length) {
+    return <p className="text-sm text-slate-500">No results found.</p>;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2 mt-2">
+      {visibleUsers.map((user, index) => (
+        <div
+          key={String(user.fid ?? user.username ?? user.display_name ?? index)}
+          className="flex items-center gap-2"
+        >
+          <Avatar className="h-8 w-8">
+            <AvatarImage src={user.pfp_url ?? undefined} alt={user.display_name || user.username || ""} />
+            <AvatarFallback>
+              {(user.display_name || user.username || "?")
+                .slice(0, 2)
+                .toUpperCase()}
+            </AvatarFallback>
+          </Avatar>
+          <div className="leading-tight">
+            <p className="text-sm font-medium text-slate-800 dark:text-slate-200">
+              {user.display_name || user.username || `FID ${user.fid}`}
+            </p>
+            {user.username && (
+              <p className="text-xs text-slate-500">@{user.username}</p>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const ChannelFidget: React.FC<FidgetArgs<ChannelFidgetSettings>> = ({
+  settings: { channelId },
+}) => {
+  const { fid: viewerFid } = useFarcasterSigner("Channel");
+
+  const { data: channelResponse, isLoading: channelLoading } = useChannelById(
+    channelId,
+    viewerFid > 0 ? viewerFid : undefined,
+  );
+  const { data: membersResponse, isLoading: membersLoading } = useChannelMembers(channelId, 6);
+  const { data: followersResponse, isLoading: followersLoading } = useChannelFollowers(channelId, 6);
+  const hasViewerFid = typeof viewerFid === "number" && viewerFid > 0;
+  const { data: relevantFollowersResponse, isLoading: relevantFollowersLoading } =
+    useChannelRelevantFollowers(channelId, hasViewerFid ? viewerFid : undefined);
+
+  const isLoading =
+    channelLoading ||
+    membersLoading ||
+    followersLoading ||
+    (hasViewerFid ? relevantFollowersLoading : false);
+
+  const channel = channelResponse?.channel;
+
+  const description = channel?.description?.trim();
+  const channelName = channel?.name || channel?.id;
+  const avatarUrl = channel?.image_url;
+  const followerUsers = useMemo(
+    () =>
+      (followersResponse?.users ?? [])
+        .map((follower) => toSimpleUser(follower?.user))
+        .filter((user): user is SimpleUser => Boolean(user)),
+    [followersResponse?.users],
+  );
+  const memberUsers = useMemo(
+    () =>
+      (membersResponse?.members ?? [])
+        .map((member) => toSimpleUser(member?.user))
+        .filter((user): user is SimpleUser => Boolean(user)),
+    [membersResponse?.members],
+  );
+  const followerCount = channel?.follower_count ?? followerUsers.length ?? 0;
+  const memberCount = channel?.member_count ?? memberUsers.length ?? 0;
+
+  const leadUser = channel?.lead || first(memberUsers);
+
+  const relevantFollowerUsers = useMemo(
+    () =>
+      (relevantFollowersResponse?.top_relevant_followers_hydrated ?? [])
+        .map((follower) => toSimpleUser(follower?.user))
+        .filter((user): user is SimpleUser => Boolean(user)),
+    [relevantFollowersResponse?.top_relevant_followers_hydrated],
+  );
+
+  if (!channelId) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-sm text-slate-500">
+        Provide a Farcaster channel ID to load channel details.
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="h-full w-full overflow-hidden rounded-xl bg-white p-6 shadow-sm dark:bg-slate-900">
+        <SkeletonSection />
+      </div>
+    );
+  }
+
+  if (!channel) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-slate-200 p-6 text-sm text-slate-500 dark:border-slate-700 dark:text-slate-300">
+        Unable to load channel information.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-6 overflow-auto rounded-xl bg-white p-6 shadow-sm dark:bg-slate-900">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center">
+        <div className="flex items-center gap-4">
+          <div className="h-16 w-16 overflow-hidden rounded-full bg-slate-200">
+            {avatarUrl ? (
+              <img src={avatarUrl} alt={channelName ?? channel.id} className="h-full w-full object-cover" />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center text-xl text-slate-500">
+                /
+              </div>
+            )}
+          </div>
+          <div className="flex flex-col">
+            <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+              {channelName}
+            </h2>
+            <p className="text-sm text-slate-500 dark:text-slate-300">/{channel.id}</p>
+          </div>
+        </div>
+        {leadUser && (
+          <div className="mt-2 flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300 md:ml-auto md:mt-0">
+            <span className="uppercase tracking-wide text-slate-500">Lead</span>
+            <span>{leadUser.display_name || leadUser.username || `FID ${leadUser.fid}`}</span>
+          </div>
+        )}
+      </div>
+
+      {description && (
+        <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-200">
+          {description}
+        </p>
+      )}
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="flex flex-col gap-3">
+          <SectionHeading title="Followers" count={followerCount} />
+          <InlineAvatarList users={followerUsers} />
+        </div>
+        <div className="flex flex-col gap-3">
+          <SectionHeading title="Members" count={memberCount} />
+          <InlineAvatarList users={memberUsers} />
+        </div>
+      </div>
+
+      <div
+        className={clsx(
+          "flex flex-col gap-3",
+          (!hasViewerFid || !relevantFollowerUsers.length) && "opacity-70",
+        )}
+      >
+        <SectionHeading title="Relevant Followers" />
+        {hasViewerFid ? (
+          <InlineAvatarList users={relevantFollowerUsers} />
+        ) : (
+          <p className="text-sm text-slate-500">
+            Sign in with Farcaster to see relevant followers for this channel.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default {
+  fidget: ChannelFidget,
+  properties: channelProperties,
+} as FidgetModule<FidgetArgs<ChannelFidgetSettings>>;

--- a/src/pages/api/farcaster/neynar/channel/followers.ts
+++ b/src/pages/api/farcaster/neynar/channel/followers.ts
@@ -1,0 +1,35 @@
+import requestHandler from "@/common/data/api/requestHandler";
+import axios, { AxiosRequestConfig, isAxiosError } from "axios";
+import { NextApiRequest, NextApiResponse } from "next/types";
+
+async function fetchChannelFollowers(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const options: AxiosRequestConfig = {
+      method: "GET",
+      url: "https://api.neynar.com/v2/farcaster/channel/followers",
+      headers: {
+        accept: "application/json",
+        api_key: process.env.NEYNAR_API_KEY!,
+      },
+      params: req.query,
+    };
+
+    const { data } = await axios.request(options);
+
+    if (data.status && data.status !== 200) {
+      return res.status(data.status).json(data);
+    }
+
+    res.status(200).json(data);
+  } catch (error) {
+    if (isAxiosError(error)) {
+      const status = error.response?.status || error.response?.data?.status || 500;
+      return res.status(status).json(error.response?.data || "An unknown error occurred");
+    }
+    res.status(500).json("An unknown error occurred");
+  }
+}
+
+export default requestHandler({
+  get: fetchChannelFollowers,
+});

--- a/src/pages/api/farcaster/neynar/channel/index.ts
+++ b/src/pages/api/farcaster/neynar/channel/index.ts
@@ -1,0 +1,35 @@
+import requestHandler from "@/common/data/api/requestHandler";
+import axios, { AxiosRequestConfig, isAxiosError } from "axios";
+import { NextApiRequest, NextApiResponse } from "next/types";
+
+async function lookupChannel(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const options: AxiosRequestConfig = {
+      method: "GET",
+      url: "https://api.neynar.com/v2/farcaster/channel",
+      headers: {
+        accept: "application/json",
+        api_key: process.env.NEYNAR_API_KEY!,
+      },
+      params: req.query,
+    };
+
+    const { data } = await axios.request(options);
+
+    if (data.status && data.status !== 200) {
+      return res.status(data.status).json(data);
+    }
+
+    res.status(200).json(data);
+  } catch (error) {
+    if (isAxiosError(error)) {
+      const status = error.response?.status || error.response?.data?.status || 500;
+      return res.status(status).json(error.response?.data || "An unknown error occurred");
+    }
+    res.status(500).json("An unknown error occurred");
+  }
+}
+
+export default requestHandler({
+  get: lookupChannel,
+});

--- a/src/pages/api/farcaster/neynar/channel/members.ts
+++ b/src/pages/api/farcaster/neynar/channel/members.ts
@@ -1,0 +1,52 @@
+import requestHandler from "@/common/data/api/requestHandler";
+import axios, { AxiosRequestConfig, isAxiosError } from "axios";
+import { NextApiRequest, NextApiResponse } from "next/types";
+
+const getSingleQueryValue = (value: string | string[] | undefined) =>
+  Array.isArray(value) ? value[0] : value;
+
+async function fetchChannelMembers(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const channelId = getSingleQueryValue(req.query.id);
+
+    if (!channelId) {
+      return res.status(400).json({
+        result: "error",
+        error: { message: "Missing required channel id" },
+      });
+    }
+
+    const { id: _unusedId, ...rest } = req.query;
+
+    const options: AxiosRequestConfig = {
+      method: "GET",
+      url: "https://api.neynar.com/v2/farcaster/channel/member/list",
+      headers: {
+        accept: "application/json",
+        api_key: process.env.NEYNAR_API_KEY!,
+      },
+      params: {
+        ...rest,
+        channel_id: channelId,
+      },
+    };
+
+    const { data } = await axios.request(options);
+
+    if (data.status && data.status !== 200) {
+      return res.status(data.status).json(data);
+    }
+
+    res.status(200).json(data);
+  } catch (error) {
+    if (isAxiosError(error)) {
+      const status = error.response?.status || error.response?.data?.status || 500;
+      return res.status(status).json(error.response?.data || "An unknown error occurred");
+    }
+    res.status(500).json("An unknown error occurred");
+  }
+}
+
+export default requestHandler({
+  get: fetchChannelMembers,
+});

--- a/src/pages/api/farcaster/neynar/channel/relevant-followers.ts
+++ b/src/pages/api/farcaster/neynar/channel/relevant-followers.ts
@@ -1,0 +1,57 @@
+import requestHandler from "@/common/data/api/requestHandler";
+import axios, { AxiosRequestConfig, isAxiosError } from "axios";
+import { NextApiRequest, NextApiResponse } from "next/types";
+
+const getSingleQueryValue = (value: string | string[] | undefined) =>
+  Array.isArray(value) ? value[0] : value;
+
+async function fetchChannelRelevantFollowers(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  try {
+    const channelId = getSingleQueryValue(req.query.id);
+    const viewerFidParam = getSingleQueryValue(req.query.viewer_fid);
+
+    if (!channelId || !viewerFidParam) {
+      return res.status(400).json({
+        result: "error",
+        error: { message: "Missing required channel id or viewer fid" },
+      });
+    }
+
+    const { id: _unusedId, viewer_fid: _unusedViewerFid, ...rest } = req.query;
+
+    const options: AxiosRequestConfig = {
+      method: "GET",
+      url: "https://api.neynar.com/v2/farcaster/channel/followers/relevant",
+      headers: {
+        accept: "application/json",
+        api_key: process.env.NEYNAR_API_KEY!,
+      },
+      params: {
+        ...rest,
+        id: channelId,
+        viewer_fid: viewerFidParam,
+      },
+    };
+
+    const { data } = await axios.request(options);
+
+    if (data.status && data.status !== 200) {
+      return res.status(data.status).json(data);
+    }
+
+    res.status(200).json(data);
+  } catch (error) {
+    if (isAxiosError(error)) {
+      const status = error.response?.status || error.response?.data?.status || 500;
+      return res.status(status).json(error.response?.data || "An unknown error occurred");
+    }
+    res.status(500).json("An unknown error occurred");
+  }
+}
+
+export default requestHandler({
+  get: fetchChannelRelevantFollowers,
+});

--- a/supabase/migrations/20240910120000_add_channel_spaces.sql
+++ b/supabase/migrations/20240910120000_add_channel_spaces.sql
@@ -1,0 +1,21 @@
+-- Add support for channel spaces
+ALTER TABLE "public"."spaceRegistrations"
+    ADD COLUMN IF NOT EXISTS "channelId" text;
+
+-- Ensure we only store valid space types, including channels
+ALTER TABLE "public"."spaceRegistrations"
+    DROP CONSTRAINT IF EXISTS valid_space_type;
+
+ALTER TABLE "public"."spaceRegistrations"
+    ADD CONSTRAINT valid_space_type CHECK (
+        "spaceType" IN ('profile', 'token', 'proposal', 'channel')
+    );
+
+-- Prevent duplicate registrations for the same channel
+CREATE UNIQUE INDEX IF NOT EXISTS "spaceRegistrations_channelId_key"
+    ON public."spaceRegistrations" ("channelId")
+    WHERE "channelId" IS NOT NULL;
+
+ALTER TABLE "public"."spaceRegistrations"
+    ADD CONSTRAINT "spaceRegistrations_channelId_key" UNIQUE
+    USING INDEX "spaceRegistrations_channelId_key";


### PR DESCRIPTION
## Summary'
- add a new /c/[channelId] public space backed by Neynar channel metadata with editable layouts for moderators
- provide a channel profile fidget, default channel layout config, and new Neynar API routes & queries for followers, members, and relevant followers
- surface channels in the global search and link cast channel badges to their space routes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9668102ac8325a2e51cff6d0507f9