### PR TITLE
Allow space builder websocket

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -32,6 +32,7 @@ const cspHeader = `
       wss://relay.walletconnect.org
       https://explorer-api.walletconnect.com
       wss://www.walletlink.org
+      wss://space-builder-server.onrender.com
       https://*.rpc.privy.systems
       https://auth.privy.io
       https://auth.privy.io/api/v1/apps/clw9qpfkl01nnpox6rcsb5wy3


### PR DESCRIPTION
## Summary
- permit connections to wss://space-builder-server.onrender.com in the CSP connect-src list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ded9f801408325993c64494acb8d1b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored real-time connectivity by allowing WebSocket connections to the app’s server, preventing CSP-related blocks. Users should see more reliable live updates and improved collaboration stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->