### PR TITLE
Refine channel fidget layout

### DIFF
--- a/src/common/data/queries/farcaster.ts
+++ b/src/common/data/queries/farcaster.ts
@@ -216,7 +216,7 @@ export const useChannelMembers = (channelId: string, limit = 10) => {
     staleTime: 1000 * 60 * 3,
     queryFn: async () => {
       const params: Record<string, number | string> = {
-        channel_id: channelId,
+        id: channelId,
       };
 
       if (typeof limit === "number") {

--- a/src/fidgets/ui/channel.tsx
+++ b/src/fidgets/ui/channel.tsx
@@ -1,18 +1,12 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/common/components/atoms/avatar";
 import TextInput from "@/common/components/molecules/TextInput";
-import {
-  useChannelById,
-  useChannelFollowers,
-  useChannelMembers,
-  useChannelRelevantFollowers,
-} from "@/common/data/queries/farcaster";
+import { useChannelById, useChannelFollowers, useChannelMembers } from "@/common/data/queries/farcaster";
 import { FidgetArgs, FidgetModule, FidgetProperties } from "@/common/fidgets";
 import { useFarcasterSigner } from "@/fidgets/farcaster";
 import { defaultStyleFields } from "@/fidgets/helpers";
-import clsx from "clsx";
-import { first, take } from "lodash";
+import { first } from "lodash";
 import Link from "next/link";
-import React, { useMemo } from "react";
+import React from "react";
 
 export type ChannelFidgetSettings = {
   channelId: string;
@@ -52,18 +46,6 @@ const SkeletonSection: React.FC = () => (
     </div>
     <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-full" />
     <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-3/4" />
-  </div>
-);
-
-const SectionHeading: React.FC<{ title: string; count?: number }> = ({
-  title,
-  count,
-}) => (
-  <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-    <span>{title}</span>
-    {typeof count === "number" && (
-      <span className="text-slate-600 dark:text-slate-300">{count.toLocaleString()}</span>
-    )}
   </div>
 );
 
@@ -115,48 +97,6 @@ const toSimpleUser = (user?: SimpleUserSource): SimpleUser | undefined => {
   };
 };
 
-const InlineAvatarList: React.FC<{
-  users: (SimpleUser | undefined)[];
-  limit?: number;
-}> = ({ users, limit = 6 }) => {
-  const visibleUsers = useMemo(
-    () => take(users.filter((user): user is SimpleUser => Boolean(user)), limit),
-    [users, limit],
-  );
-
-  if (!visibleUsers.length) {
-    return <p className="text-sm text-slate-500">No results found.</p>;
-  }
-
-  return (
-    <div className="flex flex-wrap gap-2 mt-2">
-      {visibleUsers.map((user, index) => (
-        <div
-          key={String(user.fid ?? user.username ?? user.display_name ?? index)}
-          className="flex items-center gap-2"
-        >
-          <Avatar className="h-8 w-8">
-            <AvatarImage src={user.pfp_url ?? undefined} alt={user.display_name || user.username || ""} />
-            <AvatarFallback>
-              {(user.display_name || user.username || "?")
-                .slice(0, 2)
-                .toUpperCase()}
-            </AvatarFallback>
-          </Avatar>
-          <div className="leading-tight">
-            <p className="text-sm font-medium text-slate-800 dark:text-slate-200">
-              {user.display_name || user.username || `FID ${user.fid}`}
-            </p>
-            {user.username && (
-              <p className="text-xs text-slate-500">@{user.username}</p>
-            )}
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-};
-
 const ChannelFidget: React.FC<FidgetArgs<ChannelFidgetSettings>> = ({
   settings: { channelId },
 }) => {
@@ -168,48 +108,21 @@ const ChannelFidget: React.FC<FidgetArgs<ChannelFidgetSettings>> = ({
   );
   const { data: membersResponse, isLoading: membersLoading } = useChannelMembers(channelId, 6);
   const { data: followersResponse, isLoading: followersLoading } = useChannelFollowers(channelId, 6);
-  const hasViewerFid = typeof viewerFid === "number" && viewerFid > 0;
-  const { data: relevantFollowersResponse, isLoading: relevantFollowersLoading } =
-    useChannelRelevantFollowers(channelId, hasViewerFid ? viewerFid : undefined);
 
-  const isLoading =
-    channelLoading ||
-    membersLoading ||
-    followersLoading ||
-    (hasViewerFid ? relevantFollowersLoading : false);
+  const isLoading = channelLoading || membersLoading || followersLoading;
 
   const channel = channelResponse?.channel;
 
   const description = channel?.description?.trim();
   const channelName = channel?.name || channel?.id;
   const avatarUrl = channel?.image_url;
-  const followerUsers = useMemo(
-    () =>
-      (followersResponse?.users ?? [])
-        .map((follower) => toSimpleUser(follower?.user))
-        .filter((user): user is SimpleUser => Boolean(user)),
-    [followersResponse?.users],
-  );
-  const memberUsers = useMemo(
-    () =>
-      (membersResponse?.members ?? [])
-        .map((member) => toSimpleUser(member?.user))
-        .filter((user): user is SimpleUser => Boolean(user)),
-    [membersResponse?.members],
-  );
-  const followerCount = channel?.follower_count ?? followerUsers.length ?? 0;
-  const memberCount = channel?.member_count ?? memberUsers.length ?? 0;
+  const followerCount = channel?.follower_count ?? followersResponse?.users?.length ?? 0;
+  const memberCount = channel?.member_count ?? membersResponse?.members?.length ?? 0;
 
-  const ownerUser = toSimpleUser(channel?.lead) || first(memberUsers);
+  const ownerUser =
+    toSimpleUser(channel?.lead) ||
+    toSimpleUser(first(membersResponse?.members)?.user ?? undefined);
   const externalLink = channel?.external_link;
-
-  const relevantFollowerUsers = useMemo(
-    () =>
-      (relevantFollowersResponse?.top_relevant_followers_hydrated ?? [])
-        .map((follower) => toSimpleUser(follower?.user))
-        .filter((user): user is SimpleUser => Boolean(user)),
-    [relevantFollowersResponse?.top_relevant_followers_hydrated],
-  );
 
   if (!channelId) {
     return (
@@ -237,8 +150,8 @@ const ChannelFidget: React.FC<FidgetArgs<ChannelFidgetSettings>> = ({
 
   return (
     <div className="flex h-full flex-col gap-6 overflow-auto rounded-xl bg-white p-6 shadow-sm dark:bg-slate-900">
-      <div className="flex flex-col gap-4 md:flex-row md:items-center">
-        <div className="flex items-center gap-4">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-start gap-4">
           <div className="h-16 w-16 overflow-hidden rounded-full bg-slate-200">
             {avatarUrl ? (
               <img src={avatarUrl} alt={channelName ?? channel.id} className="h-full w-full object-cover" />
@@ -253,100 +166,82 @@ const ChannelFidget: React.FC<FidgetArgs<ChannelFidgetSettings>> = ({
               {channelName}
             </h2>
             <p className="text-sm text-slate-500 dark:text-slate-300">/{channel.id}</p>
+            {ownerUser && (
+              <div className="mt-3 inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                <span className="uppercase tracking-wide text-slate-500">Owner</span>
+                {ownerUser.username ? (
+                  <Link
+                    href={`/s/${ownerUser.username}`}
+                    className="flex items-center gap-2 text-slate-700 transition hover:text-blue-600 dark:text-slate-200 dark:hover:text-blue-400"
+                  >
+                    <Avatar className="h-6 w-6">
+                      <AvatarImage
+                        src={ownerUser.pfp_url ?? undefined}
+                        alt={ownerUser.display_name || ownerUser.username || ""}
+                      />
+                      <AvatarFallback>
+                        {(ownerUser.display_name || ownerUser.username || "?")
+                          .slice(0, 2)
+                          .toUpperCase()}
+                      </AvatarFallback>
+                    </Avatar>
+                    <span>{ownerUser.display_name || ownerUser.username || `FID ${ownerUser.fid}`}</span>
+                  </Link>
+                ) : (
+                  <div className="flex items-center gap-2 text-slate-700 dark:text-slate-200">
+                    <Avatar className="h-6 w-6">
+                      <AvatarImage src={ownerUser.pfp_url ?? undefined} alt={ownerUser.display_name || ""} />
+                      <AvatarFallback>
+                        {(ownerUser.display_name || "?")
+                          .slice(0, 2)
+                          .toUpperCase()}
+                      </AvatarFallback>
+                    </Avatar>
+                    <span>{ownerUser.display_name || `FID ${ownerUser.fid}`}</span>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         </div>
-          {ownerUser && (
-            <div className="mt-2 flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300 md:ml-auto md:mt-0">
-              <span className="uppercase tracking-wide text-slate-500">Owner</span>
-              {ownerUser.username ? (
-                <Link
-                  href={`/s/${ownerUser.username}`}
-                  className="flex items-center gap-2 text-slate-700 transition hover:text-blue-600 dark:text-slate-200 dark:hover:text-blue-400"
-                >
-                  <Avatar className="h-6 w-6">
-                    <AvatarImage src={ownerUser.pfp_url ?? undefined} alt={ownerUser.display_name || ownerUser.username || ""} />
-                    <AvatarFallback>
-                      {(ownerUser.display_name || ownerUser.username || "?")
-                        .slice(0, 2)
-                        .toUpperCase()}
-                    </AvatarFallback>
-                  </Avatar>
-                  <span>{ownerUser.display_name || ownerUser.username || `FID ${ownerUser.fid}`}</span>
-                </Link>
-              ) : (
-                <div className="flex items-center gap-2 text-slate-700 dark:text-slate-200">
-                  <Avatar className="h-6 w-6">
-                    <AvatarImage src={ownerUser.pfp_url ?? undefined} alt={ownerUser.display_name || ""} />
-                    <AvatarFallback>
-                      {(ownerUser.display_name || "?")
-                        .slice(0, 2)
-                        .toUpperCase()}
-                    </AvatarFallback>
-                  </Avatar>
-                  <span>{ownerUser.display_name || `FID ${ownerUser.fid}`}</span>
-                </div>
-              )}
-            </div>
+        <div className="flex flex-wrap items-center gap-4 text-sm text-slate-600 dark:text-slate-300">
+          <div className="flex flex-col">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              Followers
+            </span>
+            <span className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+              {followerCount.toLocaleString()}
+            </span>
+          </div>
+          <div className="flex flex-col">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              Members
+            </span>
+            <span className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+              {memberCount.toLocaleString()}
+            </span>
+          </div>
+        </div>
+      </div>
+      {(description || externalLink?.url) && (
+        <div className="space-y-3">
+          {description && (
+            <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-200">
+              {description}
+            </p>
           )}
-      </div>
-
-      <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-slate-600 dark:text-slate-300">
-        <span>
-          <span className="font-semibold text-slate-900 dark:text-slate-100">
-            {followerCount.toLocaleString()}
-          </span>{" "}
-          Followers
-        </span>
-        <span>
-          <span className="font-semibold text-slate-900 dark:text-slate-100">
-            {memberCount.toLocaleString()}
-          </span>{" "}
-          Members
-        </span>
-        {externalLink?.url && (
-          <a
-            href={externalLink.url}
-            target="_blank"
-            rel="noreferrer"
-            className="flex items-center gap-1 text-blue-600 hover:underline dark:text-blue-400"
-          >
-            <span className="font-medium">{externalLink.title || "External Link"}</span>
-          </a>
-        )}
-      </div>
-
-      {description && (
-        <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-200">
-          {description}
-        </p>
+          {externalLink?.url && (
+            <a
+              href={externalLink.url}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-sm font-medium text-blue-600 hover:underline dark:text-blue-400"
+            >
+              <span>{externalLink.title || "External Link"}</span>
+            </a>
+          )}
+        </div>
       )}
-
-      <div className="grid gap-6 md:grid-cols-2">
-        <div className="flex flex-col gap-3">
-          <SectionHeading title="Followers" count={followerCount} />
-          <InlineAvatarList users={followerUsers} />
-        </div>
-        <div className="flex flex-col gap-3">
-          <SectionHeading title="Members" count={memberCount} />
-          <InlineAvatarList users={memberUsers} />
-        </div>
-      </div>
-
-      <div
-        className={clsx(
-          "flex flex-col gap-3",
-          (!hasViewerFid || !relevantFollowerUsers.length) && "opacity-70",
-        )}
-      >
-        <SectionHeading title="Relevant Followers" />
-        {hasViewerFid ? (
-          <InlineAvatarList users={relevantFollowerUsers} />
-        ) : (
-          <p className="text-sm text-slate-500">
-            Sign in with Farcaster to see relevant followers for this channel.
-          </p>
-        )}
-      </div>
     </div>
   );
 };

--- a/src/fidgets/ui/channel.tsx
+++ b/src/fidgets/ui/channel.tsx
@@ -150,8 +150,8 @@ const ChannelFidget: React.FC<FidgetArgs<ChannelFidgetSettings>> = ({
 
   return (
     <div className="flex h-full flex-col gap-6 overflow-auto rounded-xl bg-white p-6 shadow-sm dark:bg-slate-900">
-      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <div className="flex items-start gap-4">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center">
+        <div className="flex flex-1 items-start gap-4">
           <div className="h-16 w-16 overflow-hidden rounded-full bg-slate-200">
             {avatarUrl ? (
               <img src={avatarUrl} alt={channelName ?? channel.id} className="h-full w-full object-cover" />
@@ -161,67 +161,71 @@ const ChannelFidget: React.FC<FidgetArgs<ChannelFidgetSettings>> = ({
               </div>
             )}
           </div>
-          <div className="flex flex-col">
-            <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
-              {channelName}
-            </h2>
-            <p className="text-sm text-slate-500 dark:text-slate-300">/{channel.id}</p>
-            {ownerUser && (
-              <div className="mt-3 inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300">
-                <span className="uppercase tracking-wide text-slate-500">Owner</span>
-                {ownerUser.username ? (
-                  <Link
-                    href={`/s/${ownerUser.username}`}
-                    className="flex items-center gap-2 text-slate-700 transition hover:text-blue-600 dark:text-slate-200 dark:hover:text-blue-400"
-                  >
-                    <Avatar className="h-6 w-6">
-                      <AvatarImage
-                        src={ownerUser.pfp_url ?? undefined}
-                        alt={ownerUser.display_name || ownerUser.username || ""}
-                      />
-                      <AvatarFallback>
-                        {(ownerUser.display_name || ownerUser.username || "?")
-                          .slice(0, 2)
-                          .toUpperCase()}
-                      </AvatarFallback>
-                    </Avatar>
-                    <span>{ownerUser.display_name || ownerUser.username || `FID ${ownerUser.fid}`}</span>
-                  </Link>
-                ) : (
-                  <div className="flex items-center gap-2 text-slate-700 dark:text-slate-200">
-                    <Avatar className="h-6 w-6">
-                      <AvatarImage src={ownerUser.pfp_url ?? undefined} alt={ownerUser.display_name || ""} />
-                      <AvatarFallback>
-                        {(ownerUser.display_name || "?")
-                          .slice(0, 2)
-                          .toUpperCase()}
-                      </AvatarFallback>
-                    </Avatar>
-                    <span>{ownerUser.display_name || `FID ${ownerUser.fid}`}</span>
-                  </div>
-                )}
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1 md:flex-row md:items-baseline md:gap-6">
+              <div>
+                <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+                  {channelName}
+                </h2>
+                <p className="text-sm text-slate-500 dark:text-slate-300">/{channel.id}</p>
+              </div>
+              <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-slate-600 dark:text-slate-300">
+                <div className="flex flex-col">
+                  <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    Followers
+                  </span>
+                  <span className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+                    {followerCount.toLocaleString()}
+                  </span>
+                </div>
+                <div className="flex flex-col">
+                  <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    Members
+                  </span>
+                  <span className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+                    {memberCount.toLocaleString()}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        {ownerUser && (
+          <div className="mt-2 flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300 md:ml-auto md:mt-0">
+            <span className="uppercase tracking-wide text-slate-500">Owner</span>
+            {ownerUser.username ? (
+              <Link
+                href={`/s/${ownerUser.username}`}
+                className="flex items-center gap-2 text-slate-700 transition hover:text-blue-600 dark:text-slate-200 dark:hover:text-blue-400"
+              >
+                <Avatar className="h-6 w-6">
+                  <AvatarImage
+                    src={ownerUser.pfp_url ?? undefined}
+                    alt={ownerUser.display_name || ownerUser.username || ""}
+                  />
+                  <AvatarFallback>
+                    {(ownerUser.display_name || ownerUser.username || "?")
+                      .slice(0, 2)
+                      .toUpperCase()}
+                  </AvatarFallback>
+                </Avatar>
+                <span>{ownerUser.display_name || ownerUser.username || `FID ${ownerUser.fid}`}</span>
+              </Link>
+            ) : (
+              <div className="flex items-center gap-2 text-slate-700 dark:text-slate-200">
+                <Avatar className="h-6 w-6">
+                  <AvatarImage src={ownerUser.pfp_url ?? undefined} alt={ownerUser.display_name || ""} />
+                  <AvatarFallback>
+                    {(ownerUser.display_name || "?")
+                      .slice(0, 2)
+                      .toUpperCase()}
+                  </AvatarFallback>
+                </Avatar>
+                <span>{ownerUser.display_name || `FID ${ownerUser.fid}`}</span>
               </div>
             )}
           </div>
-        </div>
-        <div className="flex flex-wrap items-center gap-4 text-sm text-slate-600 dark:text-slate-300">
-          <div className="flex flex-col">
-            <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-              Followers
-            </span>
-            <span className="text-lg font-semibold text-slate-900 dark:text-slate-100">
-              {followerCount.toLocaleString()}
-            </span>
-          </div>
-          <div className="flex flex-col">
-            <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-              Members
-            </span>
-            <span className="text-lg font-semibold text-slate-900 dark:text-slate-100">
-              {memberCount.toLocaleString()}
-            </span>
-          </div>
-        </div>
+        )}
       </div>
       {(description || externalLink?.url) && (
         <div className="space-y-3">

--- a/src/fidgets/ui/channel.tsx
+++ b/src/fidgets/ui/channel.tsx
@@ -134,7 +134,7 @@ const ChannelFidget: React.FC<FidgetArgs<ChannelFidgetSettings>> = ({
 
   if (isLoading) {
     return (
-      <div className="h-full w-full overflow-hidden rounded-xl bg-white p-6 shadow-sm dark:bg-slate-900">
+      <div className="h-full w-full overflow-hidden rounded-xl bg-white p-6 dark:bg-slate-900">
         <SkeletonSection />
       </div>
     );
@@ -149,7 +149,7 @@ const ChannelFidget: React.FC<FidgetArgs<ChannelFidgetSettings>> = ({
   }
 
   return (
-    <div className="flex h-full flex-col gap-6 overflow-auto rounded-xl bg-white p-6 shadow-sm dark:bg-slate-900">
+    <div className="flex h-full flex-col gap-6 overflow-auto rounded-xl bg-white p-6 dark:bg-slate-900">
       <div className="flex flex-col gap-4 md:flex-row md:items-center">
         <div className="flex flex-1 items-start gap-4">
           <div className="h-16 w-16 overflow-hidden rounded-full bg-slate-200">

--- a/src/fidgets/ui/channel.tsx
+++ b/src/fidgets/ui/channel.tsx
@@ -36,10 +36,10 @@ const channelProperties: FidgetProperties = {
 };
 
 const SkeletonSection: React.FC = () => (
-  <div className="flex flex-col gap-4 animate-pulse">
-    <div className="flex items-center gap-4">
+  <div className="flex flex-col gap-3 animate-pulse">
+    <div className="flex items-center gap-3">
       <div className="h-16 w-16 rounded-full bg-gray-200 dark:bg-gray-700" />
-      <div className="flex flex-col gap-2 flex-1">
+      <div className="flex flex-1 flex-col gap-2">
         <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
         <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-1/2" />
       </div>
@@ -134,7 +134,7 @@ const ChannelFidget: React.FC<FidgetArgs<ChannelFidgetSettings>> = ({
 
   if (isLoading) {
     return (
-      <div className="h-full w-full overflow-hidden rounded-xl bg-white p-6 dark:bg-slate-900">
+      <div className="h-full w-full overflow-hidden rounded-xl bg-white p-5 dark:bg-slate-900">
         <SkeletonSection />
       </div>
     );
@@ -149,9 +149,9 @@ const ChannelFidget: React.FC<FidgetArgs<ChannelFidgetSettings>> = ({
   }
 
   return (
-    <div className="flex h-full flex-col gap-6 overflow-auto rounded-xl bg-white p-6 dark:bg-slate-900">
-      <div className="flex flex-col gap-4 md:flex-row md:items-center">
-        <div className="flex flex-1 items-start gap-4">
+    <div className="flex h-full flex-col gap-5 overflow-auto rounded-xl bg-white p-5 dark:bg-slate-900">
+      <div className="relative flex flex-col gap-3 md:flex-row md:items-center">
+        <div className="flex flex-1 items-start gap-3 pr-20 md:gap-4 md:pr-0">
           <div className="h-16 w-16 overflow-hidden rounded-full bg-slate-200">
             {avatarUrl ? (
               <img src={avatarUrl} alt={channelName ?? channel.id} className="h-full w-full object-cover" />
@@ -161,15 +161,15 @@ const ChannelFidget: React.FC<FidgetArgs<ChannelFidgetSettings>> = ({
               </div>
             )}
           </div>
-          <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-2">
             <div className="flex flex-col gap-1 md:flex-row md:items-baseline md:gap-6">
-              <div>
+              <div className="min-w-0">
                 <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
                   {channelName}
                 </h2>
                 <p className="text-sm text-slate-500 dark:text-slate-300">/{channel.id}</p>
               </div>
-              <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-slate-600 dark:text-slate-300">
+              <div className="hidden flex-wrap items-start gap-x-6 gap-y-1 text-sm text-slate-600 dark:text-slate-300 md:flex">
                 <div className="flex flex-col">
                   <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
                     Followers
@@ -188,10 +188,18 @@ const ChannelFidget: React.FC<FidgetArgs<ChannelFidgetSettings>> = ({
                 </div>
               </div>
             </div>
+            <div className="flex items-center gap-3 text-sm md:hidden">
+              <p>
+                <span className="font-bold">{followerCount.toLocaleString()}</span> Followers
+              </p>
+              <p>
+                <span className="font-bold">{memberCount.toLocaleString()}</span> Members
+              </p>
+            </div>
           </div>
         </div>
         {ownerUser && (
-          <div className="mt-2 flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300 md:ml-auto md:mt-0">
+          <div className="absolute right-0 top-0 flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300 md:static md:ml-auto md:mt-0">
             <span className="uppercase tracking-wide text-slate-500">Owner</span>
             {ownerUser.username ? (
               <Link
@@ -228,7 +236,7 @@ const ChannelFidget: React.FC<FidgetArgs<ChannelFidgetSettings>> = ({
         )}
       </div>
       {(description || externalLink?.url) && (
-        <div className="space-y-3">
+        <div className="space-y-2">
           {description && (
             <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-200">
               {description}


### PR DESCRIPTION
## Summary
- move channel follower and member counts alongside the channel header details and surface the description beneath
- drop the follower/member list sections and the relevant follower query to simplify the channel fidget UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68def9eea144832594ed11c3e3c75f71