### PR TITLE
Revert "Fix/publicspace loading render (#1468)" and fix race condition on public spaces

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -87,14 +87,12 @@ export default function PublicSpace({
 
   const router = useRouter();
 
-  // State to control initial loading of the space
-  const [initialLoading, setInitialLoading] = useState(
+  const initialLoading =
     spacePageData.spaceId !== undefined &&
     spacePageData.spaceId !== "" &&
-    !localSpaces[spacePageData.spaceId]);
+    !localSpaces[spacePageData.spaceId];
 
-  const [tabLoading, setTabLoading] = useState(false);
-
+  const [loading, setLoading] = useState<boolean>(initialLoading);
   const [currentUserFid, setCurrentUserFid] = useState<number | null>(null);
   const [isSignedIntoFarcaster, setIsSignedIntoFarcaster] = useState(false);
   const { wallets } = useWallets();
@@ -229,53 +227,65 @@ export default function PublicSpace({
 
     if (!isNil(currentSpaceId)) {
       let loadPromise;
+      
       if (!initialDataLoadRef.current) {
+        // First load - load everything from the database
         isLoadingRef.current = true;
-        setTabLoading(true); // set tab loading state
+        setLoading(true);
         loadPromise = loadSpaceTabOrder(currentSpaceId)
           .then(() => {
             return loadEditableSpaces();
           })
           .then(() => {
+            // Load the current tab from the database
             return loadSpaceTab(currentSpaceId, currentTabName, currentUserFid || undefined);
           });
       } else {
+        // Navigation between tabs - check if we already have the tab in local cache
         const tabExists = localSpaces[currentSpaceId]?.tabs?.[currentTabName];
+        // Also check if the tab is marked as loaded in our registry
         const isTabCached = loadedTabsRef.current[currentSpaceId]?.has(currentTabName);
+
         if (tabExists && isTabCached) {
-          setTabLoading(false);
+          setLoading(false);
           isLoadingRef.current = false;
           loadPromise = Promise.resolve();
+          
+          // Ensure that the tab is registered as loaded
           if (!loadedTabsRef.current[currentSpaceId]) {
             loadedTabsRef.current[currentSpaceId] = new Set();
           }
           loadedTabsRef.current[currentSpaceId].add(currentTabName);
         } else {
-          setTabLoading(true);
+          // Tab not available, need to load from database
+          setLoading(true);
           isLoadingRef.current = true;
           loadPromise = loadSpaceTab(currentSpaceId, currentTabName, currentUserFid || undefined);
         }
       }
+      
       loadPromise
         .then(() => {
+          setLoading(false);
+          isLoadingRef.current = false;
+          initialDataLoadRef.current = true;
+          
+          // Mark the current tab as loaded in our registry
           if (currentSpaceId) {
             if (!loadedTabsRef.current[currentSpaceId]) {
               loadedTabsRef.current[currentSpaceId] = new Set();
             }
             loadedTabsRef.current[currentSpaceId].add(currentTabName);
           }
-          // ensure loadRemainingTabs is called only on first load
-          const wasFirstLoad = !initialDataLoadRef.current;
-          setTabLoading(false);
-          isLoadingRef.current = false;
-          initialDataLoadRef.current = true;
-          if (currentSpaceId && wasFirstLoad) {
+          
+          // Load remaining tabs in the background if necessary
+          if (currentSpaceId && !initialDataLoadRef.current) {
             void loadRemainingTabs(currentSpaceId);
           }
         })
         .catch((error) => {
           console.error("Error loading space:", error);
-          setTabLoading(false);
+          setLoading(false);
           isLoadingRef.current = false;
         });
     }
@@ -344,7 +354,7 @@ export default function PublicSpace({
       isEditable &&
       isNil(currentSpaceId) &&
       !isNil(currentUserFid) &&
-      !tabLoading
+      !loading
     ) {
 
       const registerSpace = async () => {
@@ -466,7 +476,7 @@ export default function PublicSpace({
   }, [
     isEditable,
     currentUserFid,
-    tabLoading,
+    loading,
     getCurrentSpaceId,
     getCurrentTabName,
     localSpaces,
@@ -572,7 +582,7 @@ export default function PublicSpace({
 
     // Protect against race condition: only execute if component is mounted
     let isMounted = true;
-    setTabLoading(true);
+    setLoading(true);
     try {
       if (!tabExists) {
         if (!loadedTabsRef.current[currentSpaceId]) {
@@ -591,7 +601,7 @@ export default function PublicSpace({
         console.error("Error loading tab:", err);
       }
     } finally {
-      if (isMounted) setTabLoading(false);
+      if (isMounted) setLoading(false);
     }
     // Clear flag on unmount
     return () => { isMounted = false; };
@@ -607,7 +617,8 @@ export default function PublicSpace({
     loadSpaceTab,
     currentUserFid,
     config,
-    setCurrentTabName
+    setCurrentTabName,
+    setLoading
   ]);
 
   // Debounce tab switching to prevent rapid clicks
@@ -727,19 +738,16 @@ export default function PublicSpace({
     />
   ), [memoizedConfig, saveConfig, commitConfig, resetConfig, tabBar, headerFidget]);
   
-  // Shows the skeleton only during the initial loading of the space
+  // Shows the skeleton only during initial space loading, not during tab switching
   const shouldShowSkeleton =
-    initialLoading &&
-    spacePageData.spaceId !== undefined && spacePageData.spaceId !== "";
-
-  // Update initial loading when the space is loaded
-  useEffect(() => {
-    setInitialLoading(
-      spacePageData.spaceId !== undefined &&
-      spacePageData.spaceId !== "" &&
-      !localSpaces[spacePageData.spaceId]
-    );
-  }, [spacePageData.spaceId, localSpaces]);
+    loading &&
+    // Show skeleton only when we haven't loaded initial data yet
+    !initialDataLoadRef.current &&
+    // Don't show skeleton for navigation between tabs
+    spacePageData.spaceId !== undefined && spacePageData.spaceId !== "" &&
+    // Avoid showing skeleton for tabs that have already been loaded
+    !(loadedTabsRef.current[getCurrentSpaceId() ?? ""] && 
+      loadedTabsRef.current[getCurrentSpaceId() ?? ""].has(getCurrentTabName() ?? spacePageData.defaultTab));
 
   if (shouldShowSkeleton) {
     return (
@@ -763,27 +771,6 @@ export default function PublicSpace({
       </div>
     );
   }
-
-  return tabLoading ? (
-    <div className="user-theme-background w-full h-full relative flex-col">
-      <div className="w-full transition-all duration-100 ease-out">
-        <div className="flex flex-col h-full">
-          {headerFidget ? (
-            <div className="z-50 bg-white md:h-40">{headerFidget}</div>
-          ) : null}
-          <TabBarSkeleton />
-          <div className="flex h-full">
-            <div className="grow">
-              <SpaceLoading
-                hasProfile={
-                  isProfileSpace(spacePageData) && spacePageData.spaceOwnerFid
-                }
-                hasFeed={false}
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  ) : MemoizedSpacePage;
+  
+  return MemoizedSpacePage;
 }


### PR DESCRIPTION
## Summary
- revert commit b85d7190ecbae22cb7f58794aaa1e98fd06a2e9a to undo the PublicSpace loading regression
- fixes the race condition that intermittently caused public spaces to display Channel as the primary tab
    - add guards to ensure a space's cached config matches the page being rendered before using it
    - resolve the active tab from the validated space instead of stale store values and gate tab actions accordingly
    - prevent loading or mutating tabs when the cached space metadata does not match the requested profile space

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6aab4db048325828d243f7098de76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Unified loading state and data-driven space/tab resolution for more consistent behavior.
  - Tabs load intelligently: current tab loads first, others in the background, with cached status per space.
  - Actions (switch, create, rename, delete, reorder, commit) now consistently resolve the correct space and tab.
- Bug Fixes
  - Reduced skeleton flashes after initial load; smoother tab navigation.
  - Improved reliability of tab switching and updates across spaces.
  - Fewer edge-case errors from mismatched space/tab context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->