### PR TITLE
Add 'default size' settings for fidgets and implement for Top 8

### DIFF
--- a/src/common/components/organisms/FidgetPicker.tsx
+++ b/src/common/components/organisms/FidgetPicker.tsx
@@ -3,6 +3,7 @@ import { CompleteFidgets } from "@/fidgets";
 import { Card, CardContent } from "../atoms/card";
 import { isUndefined, map } from "lodash";
 import { FidgetArgs, FidgetInstanceData, FidgetModule } from "@/common/fidgets";
+import { getInitialGridSize } from "@/common/fidgets/utils";
 import BackArrowIcon from "../atoms/icons/BackArrow";
 
 export interface FidgetPickerProps {
@@ -44,10 +45,11 @@ export const FidgetPicker: React.FC<FidgetPickerProps> = ({
                 "text/plain",
                 JSON.stringify(generateFidgetInstance(fidgetId, fidgetModule)),
               );
+              const initialSize = getInitialGridSize(fidgetModule.properties);
               setExternalDraggedItem({
                 i: fidgetId,
-                w: fidgetModule.properties.size.minWidth,
-                h: fidgetModule.properties.size.minHeight,
+                w: initialSize.width,
+                h: initialSize.height,
               });
             }}
           >

--- a/src/common/components/organisms/FidgetPickerModal.tsx
+++ b/src/common/components/organisms/FidgetPickerModal.tsx
@@ -2,6 +2,7 @@ import React, { Dispatch, SetStateAction, useState, useEffect, useMemo, useCallb
 import { CompleteFidgets } from "@/fidgets";
 import { Card, CardContent } from "../atoms/card";
 import { FidgetArgs, FidgetInstanceData, FidgetModule } from "@/common/fidgets";
+import { getInitialGridSize } from "@/common/fidgets/utils";
 import Modal from "../molecules/Modal";
 import { FidgetOptionsService } from "@/common/data/services/fidgetOptionsService";
 import { 
@@ -313,10 +314,11 @@ export const FidgetPickerModal: React.FC<FidgetPickerModalProps> = ({
                 "text/plain",
                 JSON.stringify(generateFidgetInstance(staticOption.fidgetType, fidgetModule)),
               );
+              const initialSize = getInitialGridSize(fidgetModule.properties);
               setExternalDraggedItem({
                 i: staticOption.fidgetType,
-                w: fidgetModule.properties.size.minWidth,
-                h: fidgetModule.properties.size.minHeight,
+                w: initialSize.width,
+                h: initialSize.height,
               });
             }
           }

--- a/src/common/data/services/fidgetOptionsService.ts
+++ b/src/common/data/services/fidgetOptionsService.ts
@@ -98,6 +98,8 @@ export class FidgetOptionsService {
           case 'frame':
           case 'chat':
           case 'profile':
+          case 'Top8':
+          case 'top8':
             primaryCategory = 'social';
             specificTags.push('farcaster');
             break;

--- a/src/common/fidgets/index.d.ts
+++ b/src/common/fidgets/index.d.ts
@@ -84,6 +84,10 @@ export type FidgetProperties<S extends FidgetSettings = FidgetSettings> = {
     minWidth: NumericRange<1, 36>;
     maxWidth: NumericRange<1, 36>;
   };
+  defaultSize?: {
+    width: NumericRange<1, 36>;
+    height: NumericRange<1, 36>;
+  };
 };
 
 export type FidgetRenderContext = {

--- a/src/common/fidgets/utils.ts
+++ b/src/common/fidgets/utils.ts
@@ -1,0 +1,19 @@
+import type { FidgetProperties } from "@/common/fidgets";
+
+const clampSize = (value: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, value));
+
+export const getInitialGridSize = (properties: FidgetProperties) => {
+  const width = clampSize(
+    properties.defaultSize?.width ?? properties.size.minWidth,
+    properties.size.minWidth,
+    properties.size.maxWidth,
+  );
+  const height = clampSize(
+    properties.defaultSize?.height ?? properties.size.minHeight,
+    properties.size.minHeight,
+    properties.size.maxHeight,
+  );
+
+  return { width, height };
+};

--- a/src/constants/mobileFidgetIcons.ts
+++ b/src/constants/mobileFidgetIcons.ts
@@ -11,6 +11,7 @@ export const DEFAULT_FIDGET_ICON_MAP: Record<string, string> = {
   Market: 'BsBarChart',
   Portfolio: 'GiTwoCoins',
   Chat: 'BsChatDots',
+  Top8: 'BsPeople',
   profile: 'BsPerson',
 };
 

--- a/src/fidgets/farcaster/Top8.tsx
+++ b/src/fidgets/farcaster/Top8.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import TextInput from "@/common/components/molecules/TextInput";
+import IFrameWidthSlider from "@/common/components/molecules/IframeScaleSlider";
+import {
+  FidgetArgs,
+  FidgetModule,
+  FidgetProperties,
+  type FidgetSettingsStyle,
+} from "@/common/fidgets";
+import { defaultStyleFields, WithMargin } from "@/fidgets/helpers";
+import { BsPeople, BsPeopleFill } from "react-icons/bs";
+
+export type Top8FidgetSettings = {
+  username: string;
+  size: number;
+} & FidgetSettingsStyle;
+
+const top8Properties: FidgetProperties = {
+  fidgetName: "Top 8",
+  icon: 0x1f465, // 👥
+  mobileIcon: <BsPeople size={20} />,
+  mobileIconSelected: <BsPeopleFill size={20} />,
+  fields: [
+    {
+      fieldName: "username",
+      displayName: "Farcaster Username",
+      default: "nounspacetom",
+      required: true,
+      inputSelector: (props) => (
+        <WithMargin>
+          <TextInput {...props} />
+        </WithMargin>
+      ),
+      group: "settings",
+    },
+    ...defaultStyleFields,
+    {
+      fieldName: "size",
+      displayName: "Scale",
+      required: false,
+      default: 1,
+      inputSelector: IFrameWidthSlider,
+      group: "style",
+    },
+  ],
+  size: {
+    minHeight: 2,
+    maxHeight: 36,
+    minWidth: 2,
+    maxWidth: 36,
+  },
+};
+
+const Top8: React.FC<FidgetArgs<Top8FidgetSettings>> = ({
+  settings,
+}) => {
+  const {
+    username = "nounspacetom",
+    size = 1,
+    background,
+    fidgetBorderColor,
+    fidgetBorderWidth,
+    fidgetShadow,
+  } = settings;
+
+  const trimmedUsername = username?.trim() || "nounspacetom";
+  const iframeUrl = `https://farcaster-top-8-frie-c060.bolt.host//${encodeURIComponent(trimmedUsername)}`;
+
+  return (
+    <div
+      style={{
+        overflow: "hidden",
+        width: "100%",
+        background,
+        borderColor: fidgetBorderColor,
+        borderWidth: fidgetBorderWidth,
+        boxShadow: fidgetShadow,
+      }}
+      className="h-[calc(100dvh-220px)] md:h-full"
+    >
+      <iframe
+        key={trimmedUsername}
+        src={iframeUrl}
+        title="Top 8"
+        sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+        style={{
+          transform: `scale(${size})`,
+          transformOrigin: "0 0",
+          width: `${100 / size}%`,
+          height: `${100 / size}%`,
+        }}
+        className="size-full"
+        frameBorder="0"
+      />
+    </div>
+  );
+};
+
+export default {
+  fidget: Top8,
+  properties: top8Properties,
+} as FidgetModule<FidgetArgs<Top8FidgetSettings>>;

--- a/src/fidgets/farcaster/Top8.tsx
+++ b/src/fidgets/farcaster/Top8.tsx
@@ -64,7 +64,7 @@ const Top8: React.FC<FidgetArgs<Top8FidgetSettings>> = ({
   } = settings;
 
   const trimmedUsername = username?.trim() || "nounspacetom";
-  const iframeUrl = `https://farcaster-top-8-frie-c060.bolt.host//${encodeURIComponent(trimmedUsername)}`;
+  const iframeUrl = `https://farcaster-top-8-frie-c060.bolt.host/${encodeURIComponent(trimmedUsername)}`;
 
   return (
     <div

--- a/src/fidgets/farcaster/Top8.tsx
+++ b/src/fidgets/farcaster/Top8.tsx
@@ -38,7 +38,7 @@ const top8Properties: FidgetProperties = {
       fieldName: "size",
       displayName: "Scale",
       required: false,
-      default: 1,
+      default: 0.6,
       inputSelector: IFrameWidthSlider,
       group: "style",
     },
@@ -49,6 +49,10 @@ const top8Properties: FidgetProperties = {
     minWidth: 2,
     maxWidth: 36,
   },
+  defaultSize: {
+    width: 4,
+    height: 5,
+  },
 };
 
 const Top8: React.FC<FidgetArgs<Top8FidgetSettings>> = ({
@@ -56,7 +60,7 @@ const Top8: React.FC<FidgetArgs<Top8FidgetSettings>> = ({
 }) => {
   const {
     username = "nounspacetom",
-    size = 1,
+    size = 0.6,
     background,
     fidgetBorderColor,
     fidgetBorderWidth,

--- a/src/fidgets/index.ts
+++ b/src/fidgets/index.ts
@@ -10,6 +10,7 @@ import Grid from "./layout/Grid";
 import NounishGovernance from "./community/nouns-dao/NounishGovernance";
 import Cast from "./farcaster/Cast";
 import Feed from "./farcaster/Feed";
+import Top8 from "./farcaster/Top8";
 // import CreateCast from "./farcaster/CreateCast";
 import Links from "./ui/Links";
 import snapShot from "./snapshot/SnapShot";
@@ -53,6 +54,7 @@ export const CompleteFidgets = {
   Market: marketData,
   Portfolio: Portfolio,
   Chat: chat,
+  Top8: Top8,
   FramesV2: FramesFidget,
 };
 


### PR DESCRIPTION
## Summary
- set the Top 8 fidget's default scale to 60% and provide a default 4x5 layout size
- add shared helpers so grid placement and pickers honor each fidget's preferred default size
- extend fidget property typing to support configurable default grid sizes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6bd97380c8325a4f62a6c184fe5ec