### PR TITLE
Handle duplicate tab rename errors

### DIFF
--- a/src/common/data/stores/app/homebase/homebaseTabsStore.ts
+++ b/src/common/data/stores/app/homebase/homebaseTabsStore.ts
@@ -404,7 +404,9 @@ export const createHomeBaseTabStoreFunc = (
         "Tab Name Already In Use",
         "Please choose a different name. Each tab must have a unique name.",
       );
-      return;
+      const error = new Error("DuplicateTabName");
+      error.name = "DuplicateTabName";
+      throw error;
     }
 
     const previousOrderLocal = cloneDeep(existingTabs);

--- a/src/common/data/stores/app/space/spaceStore.ts
+++ b/src/common/data/stores/app/space/spaceStore.ts
@@ -359,7 +359,9 @@ export const createSpaceStoreFunc = (
         "Tab Name Already In Use",
         "Please choose a different name. Each tab must have a unique name.",
       );
-      return;
+      const error = new Error("DuplicateTabName");
+      error.name = "DuplicateTabName";
+      throw error;
     }
 
     const previousTabState = existingSpace.tabs?.[tabName];


### PR DESCRIPTION
## Summary
- throw a DuplicateTabName error when a homebase tab rename collides with existing tabs
- surface duplicate rename errors in the space store so callers stop local updates

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e93c710e588325a4c68172e8af39e7