### PR TITLE
 Fix: Persist Selected Tab in Theme Editor

### DIFF
--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -169,6 +169,8 @@ const useMobileAppsManager = (
 
   return { miniApps, handleUpdateMiniApp, handleReorderMiniApps };
 };
+// Persistence of the selected tab
+const LOCAL_STORAGE_KEY = 'themeEditorTab';
 
 export function ThemeSettingsEditor({
   theme = DEFAULT_THEME,
@@ -182,8 +184,6 @@ export function ThemeSettingsEditor({
   onApplySpaceConfig,
 }: ThemeSettingsEditorArgs) {
   const [showConfirmCancel, setShowConfirmCancel] = useState(false);
-  // Persistence of the selected tab
-  const LOCAL_STORAGE_KEY = 'themeEditorTab';
   const { mobilePreview, setMobilePreview } = useMobilePreview();
   // Retrieve from localStorage or context
   const getInitialTab = () => {
@@ -194,18 +194,17 @@ export function ThemeSettingsEditor({
     return mobilePreview ? ThemeEditorTab.MOBILE : ThemeEditorTab.SPACE;
   };
   const [tabValue, setTabValue] = useState<ThemeEditorTab>(getInitialTab());
-  const tabValueRef = React.useRef(tabValue);
 
   useEffect(() => {
-    tabValueRef.current = tabValue;
     // Save to localStorage whenever it changes
     if (typeof window !== 'undefined') {
-      localStorage.setItem(LOCAL_STORAGE_KEY, tabValue);
+      try {
+        localStorage.setItem(LOCAL_STORAGE_KEY, tabValue);
+      } catch {
+        // Intentionally ignore localStorage errors
+      }
     }
-  }, [tabValue]);
-
-  useEffect(() => {
-    setMobilePreview(tabValueRef.current === ThemeEditorTab.MOBILE);
+    setMobilePreview(tabValue === ThemeEditorTab.MOBILE);
   }, [tabValue, setMobilePreview]);
 
   const [showVibeEditor, setShowVibeEditor] = useState(false);
@@ -366,7 +365,7 @@ export function ThemeSettingsEditor({
 
             {/* Templates Dropdown */}
             <div className="min-w-0">
-              <Tabs value={String(tabValue)} onValueChange={(value) => {
+              <Tabs value={tabValue} onValueChange={(value) => {
                 if (Object.values(ThemeEditorTab).includes(value as ThemeEditorTab)) {
                   setTabValue(value as ThemeEditorTab);
                 }

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -35,6 +35,7 @@ import SpaceTabContent from "./components/SpaceTabContent";
 import StyleTabContent from "./components/StyleTabContent";
 import ThemeSettingsTabs from "./components/ThemeSettingsTabs";
 import ThemeSettingsTooltip from "./components/ThemeSettingsTooltip";
+import React from "react";
 
 export type ThemeSettingsEditorArgs = {
   theme: ThemeSettings;
@@ -181,8 +182,32 @@ export function ThemeSettingsEditor({
   onApplySpaceConfig,
 }: ThemeSettingsEditorArgs) {
   const [showConfirmCancel, setShowConfirmCancel] = useState(false);
+  // Persistence of the selected tab
+  const LOCAL_STORAGE_KEY = 'themeEditorTab';
   const { mobilePreview, setMobilePreview } = useMobilePreview();
-  const [tabValue, setTabValue] = useState(mobilePreview ? ThemeEditorTab.MOBILE : ThemeEditorTab.SPACE);
+  // Retrieve from localStorage or context
+  const getInitialTab = () => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem(LOCAL_STORAGE_KEY) : null;
+    if (stored && Object.values(ThemeEditorTab).includes(stored as ThemeEditorTab)) {
+      return stored as ThemeEditorTab;
+    }
+    return mobilePreview ? ThemeEditorTab.MOBILE : ThemeEditorTab.SPACE;
+  };
+  const [tabValue, setTabValue] = useState<ThemeEditorTab>(getInitialTab());
+  const tabValueRef = React.useRef(tabValue);
+
+  useEffect(() => {
+    tabValueRef.current = tabValue;
+    // Save to localStorage whenever it changes
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(LOCAL_STORAGE_KEY, tabValue);
+    }
+  }, [tabValue]);
+
+  useEffect(() => {
+    setMobilePreview(tabValueRef.current === ThemeEditorTab.MOBILE);
+  }, [tabValue, setMobilePreview]);
+
   const [showVibeEditor, setShowVibeEditor] = useState(false);
 
   // Our theme and mobile app helpers
@@ -209,10 +234,6 @@ export function ThemeSettingsEditor({
     }
     return { theme: theme };
   }, [getCurrentSpaceContext, theme]);
-
-  useEffect(() => {
-    setMobilePreview(tabValue === ThemeEditorTab.MOBILE);
-  }, [tabValue, setMobilePreview]);
 
   const {
     background,
@@ -345,7 +366,11 @@ export function ThemeSettingsEditor({
 
             {/* Templates Dropdown */}
             <div className="min-w-0">
-              <Tabs value={tabValue} onValueChange={(value) => setTabValue(value as ThemeEditorTab)}>
+              <Tabs value={String(tabValue)} onValueChange={(value) => {
+                if (Object.values(ThemeEditorTab).includes(value as ThemeEditorTab)) {
+                  setTabValue(value as ThemeEditorTab);
+                }
+              }}>
                 {/* controlled Tabs */}
                 <ThemeSettingsTabs activeTab={tabValue} onTabChange={setTabValue} />
                 {/* Fonts */}


### PR DESCRIPTION

### Problem
When switching between the "Mobile" and "Fidgets" tabs in the theme editor, the tab was reset to "Space" due to loss of local state when the component was unmounted and remounted.

### Solution
- The selected tab is now persisted in `localStorage` (key: `themeEditorTab`).
- Whenever the user changes the tab, the value is saved and restored when the editor is opened.
- This ensures that, when switching between "Mobile" and "Fidgets", the editor always opens on the last tab selected by the user.

### File changed
- `src/common/lib/theme/ThemeSettingsEditor.tsx`

### How it works
- The tab state is initialized from the value saved in `localStorage` or, if it does not exist, from the context (`mobilePreview`).
- The value is updated and saved in `localStorage` whenever the user changes the tab.

### Impact
- Users have a more consistent and smooth experience when editing themes, without unexpected tab resets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Theme editor now remembers your last selected tab between sessions and restores a sensible default when none exists.

* **Bug Fixes**
  * Mobile preview synchronization improved to reliably reflect the active tab.
  * Prevents invalid tab selections through stricter validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->