### PR TITLE
Lower frame embed z-index under mobile nav

### DIFF
--- a/src/fidgets/framesV2/components/FrameRenderer.tsx
+++ b/src/fidgets/framesV2/components/FrameRenderer.tsx
@@ -187,7 +187,7 @@ export default function FrameRenderer({
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-            zIndex: 10,
+            zIndex: 0,
           }}
           role="status"
           aria-live="polite"
@@ -313,7 +313,7 @@ export default function FrameRenderer({
               position: "relative",
               width: "100%",
               height: "100%",
-              zIndex: 1,
+              zIndex: -1,
             }}
           >
             <Image
@@ -342,7 +342,7 @@ export default function FrameRenderer({
             left: 0,
             right: 0,
             bottom: 0,
-            zIndex: 2,
+            zIndex: 0,
             width: "100%",
             background: "rgba(255,255,255,0.95)",
             display: "flex",

--- a/src/fidgets/framesV2/components/FrameRenderer.tsx
+++ b/src/fidgets/framesV2/components/FrameRenderer.tsx
@@ -304,6 +304,7 @@ export default function FrameRenderer({
           background: "#fff",
           position: "relative",
           overflow: "hidden",
+          zIndex: 0,
         }}
       >
         {/* Frame image (responsive, fills container) */}
@@ -313,7 +314,7 @@ export default function FrameRenderer({
               position: "relative",
               width: "100%",
               height: "100%",
-              zIndex: -1,
+              zIndex: 0,
             }}
           >
             <Image


### PR DESCRIPTION
## Summary
- reduce the stacking values used by the frame renderer overlays so mini app embeds sit beneath the mobile bottom navigation while staying above the feed fidget background

Steps to repro:

- On mobile, navigate to a feed fidget and find a mini app embed card in a cast. scroll the feed fidget so the mini app preview card intersects with the bottom nav, and see that the mini app embed card is displayed above the bottom nav.

Example in prod:
https://github.com/user-attachments/assets/c811fc90-2ac5-4721-beb0-c31734dc9ed9

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f00119643c83259cafd91999686ef9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Adjusted z-index values across FrameRenderer UI layers, including loading overlay, frame container, image wrapper, and bottom overlay, to standardize stacking order.
  - Ensures overlays and content render in correct visual order, reducing unexpected overlap and improving visual consistency during loading and interaction.
  - No changes to data flow or controls; only visual stacking adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->