### PR TITLE
Allow additional streaming domains in CSP

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,7 +12,7 @@ const cspHeader = `
     default-src 'self';
     script-src 'self' 'unsafe-eval' 'unsafe-inline' https://challenges.cloudflare.com https://www.youtube.com https://www.youtube.com/iframe_api https://auth.privy.nounspace.com https://cdn.segment.com;
     style-src 'self' 'unsafe-inline' https://i.ytimg.com https://mint.highlight.xyz;
-    media-src 'self' blob: data: https://stream.warpcast.com https://stream.farcaster.xyz https://res.cloudinary.com/;
+    media-src 'self' blob: data: https://stream.warpcast.com https://stream.farcaster.xyz https://res.cloudinary.com/ https://*.cloudflarestream.com https://*.b-cdn.net;
     img-src 'self' blob: data: https:;
     font-src 'self' https: data: blob: https://fonts.googleapis.com https://fonts.gstatic.com;
     object-src 'none';
@@ -48,7 +48,10 @@ const cspHeader = `
       https://api.coingecko.com
       https://stream.warpcast.com
       https://stream.farcaster.xyz
-      https://res.cloudinary.com/;
+      https://res.cloudinary.com/
+      https://*.cloudflarestream.com
+      https://*.b-cdn.net
+      https://cca-lite.coinbase.com;
 
     upgrade-insecure-requests;
 `;


### PR DESCRIPTION
## Summary
- allow Cloudflare Stream and Bunny CDN hosts for media playback
- permit connections to Coinbase's cca-lite service

## Testing
- npm run lint
- npm run check-types

------
https://chatgpt.com/codex/tasks/task_e_68f295355ce883259687cb5852178db4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security policies to enable support for additional external service providers and content delivery networks, expanding platform capabilities while maintaining security standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->