### PR TITLE
Use Next.js rewrite for homepage instead of redirect

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -84,11 +84,6 @@ const nextConfig = {
   async redirects() {
     return [
       {
-        source: "/",
-        destination: "/home/Nouns",
-        permanent: true,
-      },
-      {
         source: "/signatures",
         destination:
           "https://docs.nounspace.com/nounspace-alpha/accounts/signatures",
@@ -103,6 +98,10 @@ const nextConfig = {
   },
   async rewrites() {
     return [
+      {
+        source: "/",
+        destination: "/home/Nouns",
+      },
       {
         source: "/home",
         destination: "/home/Nouns",


### PR DESCRIPTION
Currently nounspace.com/ redirects to nounspace.com/home/Nouns/

From an SEO perspective, google will not rank pages that have a redirect, and we lose some link juice from other domains that link to nounspace.com; Rather than redirecting nounspace.com/ to nounspace.com/home/Nouns, this adds an internal rewrite so /home/Nouns is rendered on /

## Summary
- remove the permanent redirect from `/` to `/home/Nouns`
- add an internal rewrite so `/` still renders the `/home/Nouns` content while preserving the root URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f654b375988325b7779be6f2f20e54