### PR TITLE
Add static homepage metadata and SSR shell

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -84,11 +84,6 @@ const nextConfig = {
   async redirects() {
     return [
       {
-        source: "/",
-        destination: "/home/Nouns",
-        permanent: true,
-      },
-      {
         source: "/signatures",
         destination:
           "https://docs.nounspace.com/nounspace-alpha/accounts/signatures",

--- a/src/app/home/HomePage.tsx
+++ b/src/app/home/HomePage.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import React, { useEffect, useMemo } from "react";
+import { useMiniKit } from "@coinbase/onchainkit/minikit";
+
+import TabBar from "@/common/components/organisms/TabBar";
+import { useAppStore } from "@/common/data/stores/app";
+import SpacePage, { SpacePageArgs } from "@/app/(spaces)/SpacePage";
+import { SpaceConfig } from "@/app/(spaces)/Space";
+
+import {
+  RESOURCES_TAB_CONFIG,
+  NOUNS_TAB_CONFIG,
+  SOCIAL_TAB_CONFIG,
+  GOVERNANCE_TAB_CONFIG,
+  FUNDED_WORKS_TAB_CONFIG,
+  PLACES_TAB_CONFIG,
+} from "./[tabname]/homePageTabsConfig";
+
+const DEFAULT_TAB_NAME = "Nouns";
+const HOME_TAB_ORDER = [
+  "Nouns",
+  "Social",
+  "Governance",
+  "Resources",
+  "Funded Works",
+  "Places",
+];
+
+const TAB_CONFIG_BY_NAME: Record<string, SpaceConfig> = {
+  Governance: GOVERNANCE_TAB_CONFIG as SpaceConfig,
+  Resources: RESOURCES_TAB_CONFIG as SpaceConfig,
+  "Funded Works": FUNDED_WORKS_TAB_CONFIG as SpaceConfig,
+  Social: SOCIAL_TAB_CONFIG as SpaceConfig,
+  Places: PLACES_TAB_CONFIG as SpaceConfig,
+  Nouns: NOUNS_TAB_CONFIG as SpaceConfig,
+};
+
+const resolveTabConfig = (tabName: string): SpaceConfig => {
+  return TAB_CONFIG_BY_NAME[tabName] ?? TAB_CONFIG_BY_NAME[DEFAULT_TAB_NAME];
+};
+
+export type HomePageProps = {
+  tabNameFromPath?: string;
+  defaultTabName?: string;
+  buildTabPath?: (tabName: string) => string;
+};
+
+const HomePage = ({
+  tabNameFromPath,
+  defaultTabName = DEFAULT_TAB_NAME,
+  buildTabPath,
+}: HomePageProps) => {
+  const { setFrameReady, isFrameReady } = useMiniKit();
+
+  const { setCurrentTabName, currentTabName } = useAppStore((state) => ({
+    setCurrentTabName: state.currentSpace.setCurrentTabName,
+    currentTabName: state.currentSpace.currentTabName,
+  }));
+
+  const resolvedDefaultTab = tabNameFromPath ?? defaultTabName;
+
+  useEffect(() => {
+    if (!isFrameReady) {
+      setFrameReady();
+    }
+  }, [isFrameReady, setFrameReady]);
+
+  useEffect(() => {
+    setCurrentTabName(resolvedDefaultTab);
+  }, [resolvedDefaultTab, setCurrentTabName]);
+
+  const activeTabName = currentTabName ?? resolvedDefaultTab;
+
+  const getSpacePageUrl = useMemo(() => {
+    if (buildTabPath) {
+      return buildTabPath;
+    }
+
+    return (tab: string) => `/home/${tab}`;
+  }, [buildTabPath]);
+
+  const tabBar = (
+    <TabBar
+      getSpacePageUrl={getSpacePageUrl}
+      inHomebase={false}
+      currentTab={activeTabName}
+      tabList={HOME_TAB_ORDER}
+      defaultTab={DEFAULT_TAB_NAME}
+      inEditMode={false}
+      updateTabOrder={async () => Promise.resolve()}
+      deleteTab={async () => Promise.resolve()}
+      createTab={async () => Promise.resolve({ tabName: activeTabName })}
+      renameTab={async () => Promise.resolve(void 0)}
+      commitTab={async () => Promise.resolve()}
+      commitTabOrder={async () => Promise.resolve()}
+      isEditable={false}
+    />
+  );
+
+  const args: SpacePageArgs = {
+    config: resolveTabConfig(activeTabName),
+    saveConfig: async () => {},
+    commitConfig: async () => {},
+    resetConfig: async () => {},
+    tabBar,
+    showFeedOnMobile: false,
+  };
+
+  return <SpacePage key={activeTabName} {...args} />;
+};
+
+export default HomePage;

--- a/src/app/home/[tabname]/page.tsx
+++ b/src/app/home/[tabname]/page.tsx
@@ -9,11 +9,11 @@ type HomeTabPageParams = {
 };
 
 type HomeTabPageProps = {
-  params: Promise<HomeTabPageParams>;
+  params: HomeTabPageParams;
 };
 
-export default async function HomeTabPage({ params }: HomeTabPageProps) {
-  const { tabname } = await params;
+export default function HomeTabPage({ params }: HomeTabPageProps) {
+  const { tabname } = params;
 
   const decodedTabName = tabname
     ? decodeURIComponent(tabname)

--- a/src/app/home/[tabname]/page.tsx
+++ b/src/app/home/[tabname]/page.tsx
@@ -4,15 +4,19 @@ import HomePage from "../HomePage";
 
 const DEFAULT_TAB_NAME = "Nouns";
 
-type HomeTabPageProps = {
-  params: {
-    tabname?: string;
-  };
+type HomeTabPageParams = {
+  tabname?: string;
 };
 
-export default function HomeTabPage({ params }: HomeTabPageProps) {
-  const decodedTabName = params.tabname
-    ? decodeURIComponent(params.tabname)
+type HomeTabPageProps = {
+  params: Promise<HomeTabPageParams>;
+};
+
+export default async function HomeTabPage({ params }: HomeTabPageProps) {
+  const { tabname } = await params;
+
+  const decodedTabName = tabname
+    ? decodeURIComponent(tabname)
     : DEFAULT_TAB_NAME;
 
   return <HomePage tabNameFromPath={decodedTabName} />;

--- a/src/app/home/[tabname]/page.tsx
+++ b/src/app/home/[tabname]/page.tsx
@@ -1,105 +1,19 @@
-"use client";
+import React from "react";
 
-import React, { useEffect } from "react";
-import { useRouter, useParams } from "next/navigation";
-import { useAppStore } from "@/common/data/stores/app";
-import SpacePage, { SpacePageArgs } from "@/app/(spaces)/SpacePage";
-import { SpaceConfig } from "@/app/(spaces)/Space";
-import TabBar from "@/common/components/organisms/TabBar";
-import { useMiniKit } from "@coinbase/onchainkit/minikit";
+import HomePage from "../HomePage";
 
-import {
-  RESOURCES_TAB_CONFIG,
-  NOUNS_TAB_CONFIG,
-  SOCIAL_TAB_CONFIG,
-  GOVERNANCE_TAB_CONFIG,
-  FUNDED_WORKS_TAB_CONFIG,
-  PLACES_TAB_CONFIG,
-} from "./homePageTabsConfig";
-import { INITIAL_SPACE_CONFIG_EMPTY } from "@/constants/initialSpaceConfig";
+const DEFAULT_TAB_NAME = "Nouns";
 
-const getTabConfig = (tabName: string) => {
-  switch (tabName) {
-    case "Governance":
-      return GOVERNANCE_TAB_CONFIG;
-    case "Resources":
-      return RESOURCES_TAB_CONFIG;
-    case "Funded Works":
-      return FUNDED_WORKS_TAB_CONFIG;
-    case "Social":
-      return SOCIAL_TAB_CONFIG;
-    case "Places":
-      return PLACES_TAB_CONFIG;
-    case "Nouns":
-      return NOUNS_TAB_CONFIG;
-    default:
-      return NOUNS_TAB_CONFIG;
-  }
-};
-
-const Home = () => {
-  const router = useRouter();
-  const params = useParams();
-  const { getIsAccountReady, getIsInitializing, setCurrentTabName, currentTabName } = useAppStore((state) => ({
-    getIsAccountReady: state.getIsAccountReady,
-    getIsInitializing: state.getIsInitializing,
-    setCurrentTabName: state.currentSpace.setCurrentTabName,
-    currentTabName: state.currentSpace.currentTabName,
-  }));
-  const isLoggedIn = getIsAccountReady();
-  const isInitializing = getIsInitializing();
-
-  // Tab ordering for homepage
-  const tabOrdering = ["Nouns", "Social", "Governance", "Resources", "Funded Works", "Places"];
-
-  const { setFrameReady, isFrameReady } = useMiniKit();
-
-  useEffect(() => {
-    if (!isFrameReady) setFrameReady();
-  }, [isFrameReady, setFrameReady]);
-
-  useEffect(() => {
-    const newTabName = params?.tabname
-      ? decodeURIComponent(params.tabname as string)
-      : "Nouns";
-
-    setCurrentTabName(newTabName);
-  }, [params?.tabname, setCurrentTabName]);
-
-  function switchTabTo(newTabName: string) {
-    // Update the store immediately for better responsiveness
-    setCurrentTabName(newTabName);
-    router.push(`/home/${newTabName}`);
-  }
-
-  const tabBar = (
-    <TabBar
-      getSpacePageUrl={(tab) => `/home/${tab}`}
-      inHomebase={false}
-      currentTab={currentTabName ?? "Nouns"}
-      tabList={tabOrdering}
-      defaultTab={"Nouns"}
-      inEditMode={false}
-      updateTabOrder={async () => Promise.resolve()}
-      deleteTab={async () => Promise.resolve()}
-      createTab={async () => Promise.resolve({ tabName: currentTabName ?? "Nouns" })}
-      renameTab={async () => Promise.resolve(void 0)}
-      commitTab={async () => Promise.resolve()}
-      commitTabOrder={async () => Promise.resolve()}
-      isEditable={false}
-    />
-  );
-
-  const args: SpacePageArgs = {
-    config: getTabConfig(currentTabName ?? "Nouns") as SpaceConfig,
-    saveConfig: async () => {},
-    commitConfig: async () => {},
-    resetConfig: async () => {},
-    tabBar: tabBar,
-    showFeedOnMobile: false,
+type HomeTabPageProps = {
+  params: {
+    tabname?: string;
   };
-
-  return <SpacePage key={currentTabName} {...args} />;
 };
 
-export default Home;
+export default function HomeTabPage({ params }: HomeTabPageProps) {
+  const decodedTabName = params.tabname
+    ? decodeURIComponent(params.tabname)
+    : DEFAULT_TAB_NAME;
+
+  return <HomePage tabNameFromPath={decodedTabName} />;
+}

--- a/src/app/home/[tabname]/page.tsx
+++ b/src/app/home/[tabname]/page.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import type { UnsafeUnwrappedParams } from "next/dist/server/request/params";
 
 import HomePage from "../HomePage";
 
@@ -9,11 +10,13 @@ type HomeTabPageParams = {
 };
 
 type HomeTabPageProps = {
-  params: HomeTabPageParams;
+  params: Promise<HomeTabPageParams>;
 };
 
+type UnwrappedHomeTabPageParams = UnsafeUnwrappedParams<HomeTabPageProps["params"]>;
+
 export default function HomeTabPage({ params }: HomeTabPageProps) {
-  const { tabname } = params;
+  const { tabname } = params as unknown as UnwrappedHomeTabPageParams;
 
   const decodedTabName = tabname
     ? decodeURIComponent(tabname)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata(): Promise<Metadata> {
       siteName: "Nounspace",
       images: [{ url: "https://nounspace.com/og.png" }],
     },
-    twitter: { card: "summary_large_image", site: "@yourhandle" },
+    twitter: { card: "summary_large_image", site: "@thenounspace" },
   };
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import type { Metadata } from "next";
+
+import HomePage from "./home/HomePage";
+
+export const dynamic = "force-static";
+export const revalidate = 3600;
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: "Nounspace — Explore Nouns",
+    description:
+      "Nounspace is a customizable social platform built by and for the Nouns DAO community. Create and share content and mini apps on Farcaster. Explore the nouniverse, bid on Nouns, participate in governance, and engage with the community. Customize your very own space and dashboard with Themes, Mini Apps, and Tabs.",
+    alternates: { canonical: "https://nounspace.com/" },
+    openGraph: {
+      title: "Nounspace",
+      description:
+        "A customizable Farcaster client for Nouns DAO with spaces, themes, tabs, and fidgets.",
+      url: "https://nounspace.com/",
+      siteName: "Nounspace",
+      images: [{ url: "https://nounspace.com/og.png" }],
+    },
+    twitter: { card: "summary_large_image", site: "@yourhandle" },
+  };
+}
+
+export default function Page() {
+  return (
+    <>
+      <h1 className="sr-only">Nounspace</h1>
+      <p className="sr-only">
+        Explore Farcaster spaces, themes, tabs, and fidgets with the Nounspace community.
+      </p>
+      <HomePage defaultTabName="Nouns" />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add a static app-router page for `/` with metadata, canonical tags, and accessible brand markup
- refactor the home tab route to reuse a shared client component so `/` and `/home/[tabname]` share the same UI
- remove the redirect from `/` to `/home/Nouns` so the homepage can be pre-rendered for crawlers

## Testing
- npm run lint
- npm run check-types

------
https://chatgpt.com/codex/tasks/task_e_68f6585b00948325aa4ad8fceaa661d5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated home page with improved SEO metadata and social previews.
  * Introduced a client-rendered Home view with explicit default tab support ("Nouns") and direct tab-by-URL rendering.

* **Refactor**
  * Simplified tab routing and page composition for clearer navigation.
  * Removed the automatic root ("/") redirect so the home page is shown directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->