### PR TITLE
Update sitemap to reflect current homepage tabs

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -16,19 +16,34 @@
 	<priority>0.9</priority>
 </url>
 <url>
-	<loc>https://www.nounspace.com/home/Nouns</loc>
-	<lastmod>2025-04-22T21:27:13+01:00</lastmod>
-	<priority>0.9</priority>
+        <loc>https://www.nounspace.com/home/Nouns</loc>
+        <lastmod>2025-04-22T21:27:13+01:00</lastmod>
+        <priority>0.9</priority>
 </url>
 <url>
-	<loc>https://www.nounspace.com/home/Nounspace</loc>
-	<lastmod>2025-04-22T21:27:13+01:00</lastmod>
-	<priority>0.9</priority>
+        <loc>https://www.nounspace.com/home/Social</loc>
+        <lastmod>2025-04-22T21:27:13+01:00</lastmod>
+        <priority>0.9</priority>
 </url>
 <url>
-	<loc>https://www.nounspace.com/home/Press</loc>
-	<lastmod>2025-04-22T21:27:13+01:00</lastmod>
-	<priority>0.9</priority>
+        <loc>https://www.nounspace.com/home/Governance</loc>
+        <lastmod>2025-04-22T21:27:13+01:00</lastmod>
+        <priority>0.9</priority>
+</url>
+<url>
+        <loc>https://www.nounspace.com/home/Resources</loc>
+        <lastmod>2025-04-22T21:27:13+01:00</lastmod>
+        <priority>0.9</priority>
+</url>
+<url>
+        <loc>https://www.nounspace.com/home/Funded%20Works</loc>
+        <lastmod>2025-04-22T21:27:13+01:00</lastmod>
+        <priority>0.9</priority>
+</url>
+<url>
+        <loc>https://www.nounspace.com/home/Places</loc>
+        <lastmod>2025-04-22T21:27:13+01:00</lastmod>
+        <priority>0.9</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/nounspacetom</loc>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,702 +2,702 @@
 		<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 <url>
 	<loc>https://www.nounspace.com/</loc>
-	<lastmod>2025-04-22T21:27:13+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>1.0</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/explore</loc>
-	<lastmod>2025-04-22T21:27:13+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>1.0</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/t/base/0x48C6740BcF807d6C47C864FaEEA15Ed4dA3910Ab/Profile</loc>
-	<lastmod>2025-04-22T21:27:13+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.9</priority>
 </url>
 <url>
-        <loc>https://www.nounspace.com/home/Nouns</loc>
-        <lastmod>2025-04-22T21:27:13+01:00</lastmod>
-        <priority>0.9</priority>
+	<loc>https://www.nounspace.com/home/Nouns</loc>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
+	<priority>0.9</priority>
 </url>
 <url>
-        <loc>https://www.nounspace.com/home/Social</loc>
-        <lastmod>2025-04-22T21:27:13+01:00</lastmod>
-        <priority>0.9</priority>
+	<loc>https://www.nounspace.com/home/Social</loc>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
+	<priority>0.9</priority>
 </url>
 <url>
-        <loc>https://www.nounspace.com/home/Governance</loc>
-        <lastmod>2025-04-22T21:27:13+01:00</lastmod>
-        <priority>0.9</priority>
+	<loc>https://www.nounspace.com/home/Governance</loc>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
+	<priority>0.9</priority>
 </url>
 <url>
-        <loc>https://www.nounspace.com/home/Resources</loc>
-        <lastmod>2025-04-22T21:27:13+01:00</lastmod>
-        <priority>0.9</priority>
+	<loc>https://www.nounspace.com/home/Resources</loc>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
+	<priority>0.9</priority>
 </url>
 <url>
-        <loc>https://www.nounspace.com/home/Funded%20Works</loc>
-        <lastmod>2025-04-22T21:27:13+01:00</lastmod>
-        <priority>0.9</priority>
+	<loc>https://www.nounspace.com/home/Funded%20Works</loc>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
+	<priority>0.9</priority>
 </url>
 <url>
-        <loc>https://www.nounspace.com/home/Places</loc>
-        <lastmod>2025-04-22T21:27:13+01:00</lastmod>
-        <priority>0.9</priority>
+	<loc>https://www.nounspace.com/home/Places</loc>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
+	<priority>0.9</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/nounspacetom</loc>
-	<lastmod>2025-04-22T21:27:13+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/willywonka.eth</loc>
-	<lastmod>2025-04-22T21:27:13+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/realitycrafter.eth</loc>
-	<lastmod>2025-04-22T21:27:13+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/skateboard</loc>
-	<lastmod>2025-04-22T21:27:13+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/notifications</loc>
-	<lastmod>2025-04-22T21:27:13+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>1.0</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/basednoun.eth</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/edunouns</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/gnars</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/nogglesboard</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/nounsbr</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/nounspace</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/vrbos</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/wtfisnouns</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/keepkey</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/shapeshift</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/pramadan.eth</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/giveth</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/publicnouns</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/skatehive</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/acidpunk.eth</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/ahmad</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/atlancoelho</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/backspace</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/bobburnquist</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/brandonmanus</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/brettdrawsstuff</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/ccarella.eth</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/cheer-up</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/chris-tographer</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/crpdaddy.eth</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/divine-comedian</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/edurubio</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/elirosales</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/eusoujp.eth</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/fcarva</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/frog</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/gramajo.eth</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/grumpy9</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/itsai</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/koh</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/lacksys.eth</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/loudman.eth</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/lukestokes</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/mikep</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/mindtoasted.eth</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/moctezuma3ro</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/ninanovello</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/nogenta</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/nounishprof</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/ponzipaddy</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/r4topunk</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/riotgoools</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/rohekbenitez.eth</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/ryannorton</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/sky</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/sleepypenguin.eth</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/spatializes</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/spookyaction-btc</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/stellaachenbach</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/theclaree</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/thejasper</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/tinyrainboot</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/valesol01</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/wpc</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/xenbh.eth</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/z2zec</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/zimardrp</loc>
-	<lastmod>2025-04-22T21:27:22+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.8</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/nounspacetom/Profile</loc>
-	<lastmod>2025-04-22T21:27:24+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/willywonka.eth/Profile</loc>
-	<lastmod>2025-04-22T21:27:24+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/realitycrafter.eth/Profile</loc>
-	<lastmod>2025-04-22T21:27:25+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/skateboard/Profile</loc>
-	<lastmod>2025-04-22T21:27:25+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/gnars/Profile</loc>
-	<lastmod>2025-04-22T21:27:27+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/nogglesboard/Profile</loc>
-	<lastmod>2025-04-22T21:27:28+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/basednoun.eth/Profile</loc>
-	<lastmod>2025-04-22T21:27:28+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/edunouns/Profile</loc>
-	<lastmod>2025-04-22T21:27:28+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/nounsbr/Profile</loc>
-	<lastmod>2025-04-22T21:27:28+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/wtfisnouns/Profile</loc>
-	<lastmod>2025-04-22T21:27:29+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/vrbos/Profile</loc>
-	<lastmod>2025-04-22T21:27:29+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/keepkey/Profile</loc>
-	<lastmod>2025-04-22T21:27:29+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/shapeshift/Profile</loc>
-	<lastmod>2025-04-22T21:27:30+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/pramadan.eth/Profile</loc>
-	<lastmod>2025-04-22T21:27:30+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/publicnouns/Profile</loc>
-	<lastmod>2025-04-22T21:27:30+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/giveth/Profile</loc>
-	<lastmod>2025-04-22T21:27:31+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/skatehive/Profile</loc>
-	<lastmod>2025-04-22T21:27:31+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/acidpunk.eth/Profile</loc>
-	<lastmod>2025-04-22T21:27:31+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/ahmad/Profile</loc>
-	<lastmod>2025-04-22T21:27:32+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/nounspace/Profile</loc>
-	<lastmod>2025-04-22T21:27:32+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/atlancoelho/Profile</loc>
-	<lastmod>2025-04-22T21:27:32+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/backspace/Profile</loc>
-	<lastmod>2025-04-22T21:27:32+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/bobburnquist/Profile</loc>
-	<lastmod>2025-04-22T21:27:33+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/brandonmanus/Profile</loc>
-	<lastmod>2025-04-22T21:27:33+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/brettdrawsstuff/Profile</loc>
-	<lastmod>2025-04-22T21:27:33+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/chris-tographer/Profile</loc>
-	<lastmod>2025-04-22T21:27:34+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/cheer-up/Profile</loc>
-	<lastmod>2025-04-22T21:27:34+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/crpdaddy.eth/Profile</loc>
-	<lastmod>2025-04-22T21:27:34+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/ccarella.eth/Profile</loc>
-	<lastmod>2025-04-22T21:27:35+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/divine-comedian/Profile</loc>
-	<lastmod>2025-04-22T21:27:35+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/edurubio/Profile</loc>
-	<lastmod>2025-04-22T21:27:35+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/frog/Profile</loc>
-	<lastmod>2025-04-22T21:27:36+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/fcarva/Profile</loc>
-	<lastmod>2025-04-22T21:27:36+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/gramajo.eth/Profile</loc>
-	<lastmod>2025-04-22T21:27:36+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/grumpy9/Profile</loc>
-	<lastmod>2025-04-22T21:27:36+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/itsai/Profile</loc>
-	<lastmod>2025-04-22T21:27:36+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/koh/Profile</loc>
-	<lastmod>2025-04-22T21:27:37+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/loudman.eth/Profile</loc>
-	<lastmod>2025-04-22T21:27:37+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/lacksys.eth/Profile</loc>
-	<lastmod>2025-04-22T21:27:37+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/lukestokes/Profile</loc>
-	<lastmod>2025-04-22T21:27:38+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/mikep/Profile</loc>
-	<lastmod>2025-04-22T21:27:38+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/mindtoasted.eth/Profile</loc>
-	<lastmod>2025-04-22T21:27:38+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/moctezuma3ro/Profile</loc>
-	<lastmod>2025-04-22T21:27:38+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/ninanovello/Profile</loc>
-	<lastmod>2025-04-22T21:27:38+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/nogenta/Profile</loc>
-	<lastmod>2025-04-22T21:27:38+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/ponzipaddy/Profile</loc>
-	<lastmod>2025-04-22T21:27:39+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/r4topunk/Profile</loc>
-	<lastmod>2025-04-22T21:27:39+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/nounishprof/Profile</loc>
-	<lastmod>2025-04-22T21:27:39+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/riotgoools/Profile</loc>
-	<lastmod>2025-04-22T21:27:40+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/rohekbenitez.eth/Profile</loc>
-	<lastmod>2025-04-22T21:27:40+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/sky/Profile</loc>
-	<lastmod>2025-04-22T21:27:40+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/ryannorton/Profile</loc>
-	<lastmod>2025-04-22T21:27:40+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/sleepypenguin.eth/Profile</loc>
-	<lastmod>2025-04-22T21:27:40+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/spatializes/Profile</loc>
-	<lastmod>2025-04-22T21:27:41+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/stellaachenbach/Profile</loc>
-	<lastmod>2025-04-22T21:27:41+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/spookyaction-btc/Profile</loc>
-	<lastmod>2025-04-22T21:27:41+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/theclaree/Profile</loc>
-	<lastmod>2025-04-22T21:27:41+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/thejasper/Profile</loc>
-	<lastmod>2025-04-22T21:27:41+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/valesol01/Profile</loc>
-	<lastmod>2025-04-22T21:27:42+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/wpc/Profile</loc>
-	<lastmod>2025-04-22T21:27:42+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/tinyrainboot/Profile</loc>
-	<lastmod>2025-04-22T21:27:42+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/z2zec/Profile</loc>
-	<lastmod>2025-04-22T21:27:43+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/xenbh.eth/Profile</loc>
-	<lastmod>2025-04-22T21:27:43+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 <url>
 	<loc>https://www.nounspace.com/s/zimardrp/Profile</loc>
-	<lastmod>2025-04-22T21:27:43+01:00</lastmod>
+	<lastmod>2025-10-22T00:00:00+00:00</lastmod>
 	<priority>0.6</priority>
 </url>
 </urlset>


### PR DESCRIPTION
## Summary
- remove outdated homepage tab routes from the sitemap
- add the current set of homepage tab URLs while keeping the root page as primary

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f8f313ebd083258a450d74da173ac4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated site indexing to add new sections: Social, Governance, Resources, Funded Works, and Places; removed a legacy home entry.
  * Normalized and refreshed last-modified timestamps across many profile and site pages to a common recent date.
  * Reordered sitemap blocks for clarity and to reflect the expanded URL set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->