### PR TITLE
Add Nouns95 homepage tab

### DIFF
--- a/src/app/home/[tabname]/homePageTabsConfig.tsx
+++ b/src/app/home/[tabname]/homePageTabsConfig.tsx
@@ -140,6 +140,75 @@ export const PLACES_TAB_CONFIG: SpaceConfig = {
   timestamp: "2025-08-12T19:44:39.689Z",
 };
 
+export const NOUNS95_TAB_CONFIG: SpaceConfig = {
+  layoutID: "4a8f17c2-58da-4dd5-b90d-88cf7b4d298d",
+  layoutDetails: {
+    layoutConfig: {
+      layout: [
+        {
+          w: 12,
+          h: 10,
+          x: 0,
+          y: 0,
+          i: "iframe:dcf9b4c1-6750-47f7-b6d3-4b53ad1d0d54",
+          minW: 2,
+          maxW: 36,
+          minH: 2,
+          maxH: 36,
+          moved: false,
+          static: false,
+          resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+          isBounded: false,
+        },
+      ],
+    },
+    layoutFidget: "grid",
+  },
+  theme: {
+    id: "Homebase-Tab Nouns95-Theme",
+    name: "Homebase-Tab Nouns95-Theme",
+    properties: {
+      background: "#ffffff",
+      backgroundHTML: "",
+      fidgetBackground: "#ffffff",
+      fidgetBorderColor: "#eeeeee",
+      fidgetBorderRadius: "0px",
+      fidgetBorderWidth: "0px",
+      fidgetShadow: "none",
+      font: "Inter",
+      fontColor: "#000000",
+      gridSpacing: "0",
+      headingsFont: "Inter",
+      headingsFontColor: "#000000",
+      musicURL: "https://www.youtube.com/watch?v=dMXlZ4y7OK4&t=1804",
+    },
+  },
+  fidgetInstanceDatums: {
+    "iframe:dcf9b4c1-6750-47f7-b6d3-4b53ad1d0d54": {
+      id: "iframe:dcf9b4c1-6750-47f7-b6d3-4b53ad1d0d54",
+      fidgetType: "iframe",
+      config: {
+        data: {},
+        editable: true,
+        settings: {
+          url: "https://nouns95.wtf/",
+          cropOffsetX: 0,
+          cropOffsetY: 0,
+          isScrollable: false,
+          showOnMobile: true,
+          background: "var(--user-theme-fidget-background)",
+          fidgetBorderWidth: "var(--user-theme-fidget-border-width)",
+          fidgetBorderColor: "var(--user-theme-fidget-border-color)",
+          fidgetShadow: "var(--user-theme-fidget-shadow)",
+        },
+      },
+    },
+  },
+  fidgetTrayContents: [],
+  isEditable: false,
+  timestamp: "2025-08-12T19:44:39.689Z",
+};
+
 export const SOCIAL_TAB_CONFIG: SpaceConfig = {
   layoutID: "48073f43-70dd-459c-be6d-e31ac89f267f",
   layoutDetails: {
@@ -586,4 +655,5 @@ export const HOMEBASE_TABS_CONFIG = {
   RESOURCES_TAB_CONFIG,
   FUNDED_WORKS_TAB_CONFIG,
   PLACES_TAB_CONFIG,
+  NOUNS95_TAB_CONFIG,
 };

--- a/src/app/home/[tabname]/page.tsx
+++ b/src/app/home/[tabname]/page.tsx
@@ -15,6 +15,7 @@ import {
   GOVERNANCE_TAB_CONFIG,
   FUNDED_WORKS_TAB_CONFIG,
   PLACES_TAB_CONFIG,
+  NOUNS95_TAB_CONFIG,
 } from "./homePageTabsConfig";
 import { INITIAL_SPACE_CONFIG_EMPTY } from "@/constants/initialSpaceConfig";
 
@@ -30,6 +31,8 @@ const getTabConfig = (tabName: string) => {
       return SOCIAL_TAB_CONFIG;
     case "Places":
       return PLACES_TAB_CONFIG;
+    case "Nouns95":
+      return NOUNS95_TAB_CONFIG;
     case "Nouns":
       return NOUNS_TAB_CONFIG;
     default:
@@ -50,7 +53,15 @@ const Home = () => {
   const isInitializing = getIsInitializing();
 
   // Tab ordering for homepage
-  const tabOrdering = ["Nouns", "Social", "Governance", "Resources", "Funded Works", "Places"];
+  const tabOrdering = [
+    "Nouns",
+    "Social",
+    "Governance",
+    "Resources",
+    "Funded Works",
+    "Places",
+    "Nouns95",
+  ];
 
   const { setFrameReady, isFrameReady } = useMiniKit();
 


### PR DESCRIPTION
Note: this won't work in vercel previews because nouns95.wtf only has nounspace.com whitelisted to embed it. can confirm that it does work by testing it in the web embed fidget in prod.

## Summary
- add a home tab configuration for Nouns95 with a full-bleed iframe embed
- include the Nouns95 tab in the homepage tab switcher ordering

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f915096c848325b09120d6031cfb35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Nouns95" tab to the homepage. This tab provides integrated access to Nouns95 content and features through a dedicated widget interface, allowing users to explore Nouns95 directly within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->