### PR TITLE
Allow editing and deleting of initial profile fidgets

### DIFF
--- a/src/constants/initialProfileSpace.ts
+++ b/src/constants/initialProfileSpace.ts
@@ -16,7 +16,7 @@ const createIntialProfileSpaceConfigForFid = (
   config.fidgetInstanceDatums = {
     "feed:profile": {
       config: {
-        editable: false,
+        editable: true,
         settings: {
           feedType: FeedType.Filter,
           users: fid,
@@ -29,7 +29,7 @@ const createIntialProfileSpaceConfigForFid = (
     },
     "Portfolio:cd627e89-d661-4255-8c4c-2242a950e93e": {
       config: {
-        editable: false,
+        editable: true,
         settings: {
           trackType: "farcaster",
           farcasterUsername: username ?? "",


### PR DESCRIPTION
## Changes
- Changed the `editable` field for the initial profile fidgets (`feed:profile` and `Portfolio`) from `false` to `true` in the `src/constants/initialProfileSpace.ts` file.
- The user can now edit and delete these fidgets normally, improving profile space customization.
- Fixes the issue reported in repository issue #1502.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Profile feed and Portfolio items are now editable within the profile configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->