### PR TITLE
Ensure all token gates check for both nOGs and $SPACE and refresh gating copy

### DIFF
--- a/src/common/components/organisms/NogsChecker.tsx
+++ b/src/common/components/organisms/NogsChecker.tsx
@@ -21,9 +21,9 @@ export default function NogsChecker() {
   return (
     <>
       <p className="mb-2">
-        For now Tabs are only for early supporters holding a nounspace OG NFT (nOGs){" "}
-        <br />
-        Mint a pair{" "}
+        Premium features like the vibe editor, AI background generation, and cast
+        enhancements are reserved for early supporters holding a nounspace OG NFT
+        (nOGs) or enough $SPACE tokens. Mint a pair{" "}
         <a
           href="https://highlight.xyz/mint/663d2717dffb7b3a490f398f"
           rel="noopener noreferrer"
@@ -35,7 +35,7 @@ export default function NogsChecker() {
         , then try again!
       </p>
       <Button disabled={isChecking} onClick={userTriggeredRecheck}>
-        {isChecking ? "Checking if you have nOGs" : "Check my nOGs!"}
+        {isChecking ? "Checking your access" : "Check access"}
       </Button>
     </>
   );

--- a/src/common/components/organisms/NogsGateButton.tsx
+++ b/src/common/components/organisms/NogsGateButton.tsx
@@ -169,13 +169,15 @@ const NogsGateButton = (props: ButtonProps) => {
       </Modal>
       <Button
         {...props}
-        onClick={(e) =>
-          gatingSatisfied
-            ? isUndefined(props.onClick)
-              ? undefined
-              : props.onClick(e)
-            : setModalOpen(true)
-        }
+        onClick={(e) => {
+          if (gatingSatisfied) {
+            return isUndefined(props.onClick) ? undefined : props.onClick(e);
+          }
+
+          setModalOpen(true);
+          checkForNogs();
+          return undefined;
+        }}
       ></Button>
     </>
   );

--- a/src/common/data/stores/app/setup/index.ts
+++ b/src/common/data/stores/app/setup/index.ts
@@ -10,7 +10,7 @@ export enum SetupStep {
   UNINITIALIZED = "Uninitialized",
   NOT_SIGNED_IN = "Please Sign in with Privy",
   SIGNED_IN = "Connecting to wallet...",
-  WALLET_CONNECTED = "Checking for nOGs...",
+  WALLET_CONNECTED = "Preparing your account...",
   TOKENS_FOUND = "Loading Identity...",
   IDENTITY_LOADED = "Loading Authenticators...",
   AUTHENTICATORS_LOADED = "Installing required Authenticators...",


### PR DESCRIPTION
## Summary
- allow the vibe editor gate to unlock when a connected wallet holds enough $SPACE tokens in addition to nOGs
- refresh the modal copy to clarify which premium features remain token gated and the updated access wording
- remove the nOGs check from the login flow to speed up login and only check for either nOGs or $SPACE holdings when user attempts to user a token-gated feature

Note: the token gate has already been removed for tabs

## Testing
- npm run lint
- npm run check-types

------
https://chatgpt.com/codex/tasks/task_e_68ffc6e0af908325bb9e3be21089ddb8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SPACE token balance verification to determine access eligibility
  * Updated messaging throughout the app to reference premium features and token requirements

* **Improvements**
  * Streamlined account preparation workflow with clearer status indicators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->