### PR TITLE
Close mobile navigation after search result selection

### DIFF
--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -33,7 +33,7 @@ import ExploreIcon from "../atoms/icons/ExploreIcon";
 import LogoutIcon from "../atoms/icons/LogoutIcon";
 import LoginIcon from "../atoms/icons/LoginIcon";
 import { AnalyticsEvent } from "@/common/constants/analyticsEvents";
-import SearchModal from "./SearchModal";
+import SearchModal, { SearchModalHandle } from "./SearchModal";
 
 type NavItemProps = {
   label: string;
@@ -73,7 +73,7 @@ const Navigation = React.memo(
   mobile = false,
   onNavigate,
 }: NavProps) => {
-  const searchRef = useRef<HTMLInputElement>(null);
+  const searchRef = useRef<SearchModalHandle | null>(null);
   const { setModalOpen, getIsAccountReady, getIsInitializing } = useAppStore(
     (state) => ({
       setModalOpen: state.setup.setModalOpen,
@@ -210,6 +210,10 @@ const Navigation = React.memo(
     searchRef.current.focus();
   }, [searchRef]);
 
+  const handleSearchResultSelect = useCallback(() => {
+    onNavigate?.();
+  }, [onNavigate]);
+
   return (
     <nav
       id="logo-sidebar"
@@ -229,7 +233,7 @@ const Navigation = React.memo(
       >
         <CreateCast afterSubmit={() => setShowCastModal(false)} />
       </Modal>
-      <SearchModal ref={searchRef} />
+      <SearchModal ref={searchRef} onResultSelect={handleSearchResultSelect} />
       <div
         className={mergeClasses(
           "pt-12 pb-12 h-full",

--- a/src/common/components/organisms/SearchModal.tsx
+++ b/src/common/components/organisms/SearchModal.tsx
@@ -8,42 +8,61 @@ import { Dialog, DialogContent } from "@/common/components/atoms/dialog";
 
 import SearchAutocompleteInput from "@/common/components/organisms/SearchAutocompleteInput";
 
-const SearchModal = React.forwardRef((props, ref) => {
-  const [isFocused, setIsFocused] = useState(false);
+export type SearchModalHandle = {
+  focus: () => void;
+};
 
-  const handleFocus = useCallback(() => {
-    setIsFocused(true);
-  }, []);
+type SearchModalProps = {
+  onResultSelect?: () => void;
+};
 
-  const handleBlur = useCallback(() => {
-    setIsFocused(false);
-  }, []);
+const SearchModal = React.forwardRef<SearchModalHandle, SearchModalProps>(
+  ({ onResultSelect }, ref) => {
+    const [isFocused, setIsFocused] = useState(false);
 
-  useImperativeHandle(ref, () => ({
-    focus: handleFocus,
-  }));
+    const handleFocus = useCallback(() => {
+      setIsFocused(true);
+    }, []);
 
-  useEffect(() => {
-    const down = (e: KeyboardEvent) => {
-      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
-        setIsFocused((open) => !open);
-      }
-      if (e.key === "Escape") {
-        setIsFocused(false);
-      }
-    };
-    document.addEventListener("keydown", down);
-    return () => document.removeEventListener("keydown", down);
-  }, []);
+    const handleBlur = useCallback(() => {
+      setIsFocused(false);
+    }, []);
 
-  return (
-    <Dialog open={isFocused} onOpenChange={setIsFocused}>
-      <DialogContent className="p-0 border-none">
-        <SearchAutocompleteInput onSelect={handleBlur} />
-      </DialogContent>
-    </Dialog>
-  );
-});
+    const handleSelect = useCallback(() => {
+      handleBlur();
+      onResultSelect?.();
+    }, [handleBlur, onResultSelect]);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        focus: handleFocus,
+      }),
+      [handleFocus],
+    );
+
+    useEffect(() => {
+      const down = (e: KeyboardEvent) => {
+        if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+          setIsFocused((open) => !open);
+        }
+        if (e.key === "Escape") {
+          setIsFocused(false);
+        }
+      };
+      document.addEventListener("keydown", down);
+      return () => document.removeEventListener("keydown", down);
+    }, []);
+
+    return (
+      <Dialog open={isFocused} onOpenChange={setIsFocused}>
+        <DialogContent className="p-0 border-none">
+          <SearchAutocompleteInput onSelect={handleSelect} />
+        </DialogContent>
+      </Dialog>
+    );
+  },
+);
 
 SearchModal.displayName = "SearchModal";
 


### PR DESCRIPTION
## Problem
Currently when a user selects a search result on mobile, the user is navigated to that search result's space, but the hamburger menu remains open.

## Summary
- allow the mobile navigation drawer to close once a search result is selected
- extend the search modal to expose a typed focus handle and selection callback

## Testing
- npm run lint
- npm run check-types

------
https://chatgpt.com/codex/tasks/task_e_6900fdeb33c483259873745bd04d9f78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search result selection now properly triggers application navigation.

* **Refactor**
  * Improved search component architecture with enhanced type safety and callback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->