### PR TITLE
Add mini app tags to brand configs and manifest

### DIFF
--- a/src/app/.well-known/farcaster.json/route.ts
+++ b/src/app/.well-known/farcaster.json/route.ts
@@ -8,6 +8,10 @@ function withValidProperties(properties: Record<string, undefined | string | str
 
 export async function GET() {
   const URL = process.env.NEXT_PUBLIC_URL as string;
+  const envTags = process.env.NEXT_PUBLIC_APP_TAGS
+    ?.split(',')
+    .map(tag => tag.trim())
+    .filter(tag => tag.length > 0);
   return Response.json({
     accountAssociation: {
       header: process.env.FARCASTER_HEADER,
@@ -28,7 +32,7 @@ export async function GET() {
       homeUrl: URL,
       webhookUrl: `${URL}/api/webhook`,
       primaryCategory: metadata.APP_PRIMARY_CATEGORY || process.env.NEXT_PUBLIC_APP_PRIMARY_CATEGORY,
-      tags: [],
+      tags: metadata.APP_TAGS && metadata.APP_TAGS.length > 0 ? metadata.APP_TAGS : envTags,
       heroImageUrl: metadata.APP_HERO_IMAGE || process.env.NEXT_PUBLIC_APP_HERO_IMAGE,
       tagline: metadata.APP_TAGLINE || process.env.NEXT_PUBLIC_APP_TAGLINE,
       ogTitle: metadata.APP_OG_TITLE || process.env.NEXT_PUBLIC_APP_OG_TITLE,

--- a/src/common/components/organisms/NogsGateButton.tsx
+++ b/src/common/components/organisms/NogsGateButton.tsx
@@ -55,7 +55,7 @@ const NogsGateButton = (props: ButtonProps) => {
   const walletAddress = user?.wallet?.address as Address | undefined;
   const { data: spaceBalanceData } = useBalance({
     address: walletAddress ?? zeroAddress,
-    token: SPACE_CONTRACT_ADDR,
+    token: SPACE_CONTRACT_ADDR as Address,
     chainId: base.id,
     query: { enabled: Boolean(walletAddress) },
   });

--- a/src/config/example/example.brand.ts
+++ b/src/config/example/example.brand.ts
@@ -3,4 +3,5 @@ export const exampleBrand = {
   displayName: "Example Community",
   tagline: "A space for Example Community",
   description: "The social hub for Example Community",
+  miniAppTags: [],
 };

--- a/src/config/nouns/nouns.brand.ts
+++ b/src/config/nouns/nouns.brand.ts
@@ -3,4 +3,5 @@ export const nounsBrand = {
   displayName: "Nouns",
   tagline: "A space for Nouns",
   description: "The social hub for Nouns",
+  miniAppTags: ["nouns", "client", "customizable", "social", "link"],
 };

--- a/src/config/systemConfig.ts
+++ b/src/config/systemConfig.ts
@@ -15,6 +15,7 @@ export interface BrandConfig {
   displayName: string;
   tagline: string;
   description: string;
+  miniAppTags: string[];
 }
 
 export interface AssetConfig {

--- a/src/constants/metadata.ts
+++ b/src/constants/metadata.ts
@@ -25,6 +25,7 @@ export const metadata = {
   APP_SUBTITLE: config.brand.tagline,
   APP_BUTTON_TITLE: 'Open Space',
   APP_DESCRIPTION: config.brand.description,
+  APP_TAGS: config.brand.miniAppTags,
   APP_SPLASH_IMAGE: `${WEBSITE_URL}${config.assets.logos.splash}`,
   SPLASH_BACKGROUND_COLOR: '#FFFFFF',
   APP_PRIMARY_CATEGORY: 'social',


### PR DESCRIPTION
## Summary
- extend the brand configuration contract to include mini app tags for each space system
- populate the nouns and example brand configs with their tag lists and surface them through shared metadata
- expose the configured tags in the Farcaster mini app manifest with an environment variable fallback

## Testing
- yarn lint
- yarn check-types *(fails: existing error `src/common/components/organisms/NogsGateButton.tsx:58:5 - error TS2322: Type 'string' is not assignable to type '\`0x${string}\'`)*

------
https://chatgpt.com/codex/tasks/task_e_69039cc22ba48325911f33de14fb5e90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App tags can now be configured from environment variables or brand settings.
  * Tags are exposed through the miniapp metadata endpoint.
  * Applications can define custom tags to describe capabilities.
  * Example and default brand configurations now include tag values for immediate use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->