### PR TITLE
Allow Fullstory analytics in CSP and privacy notice

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,10 +10,10 @@ const withBundleAnalyzer = bundlerAnalyzer({
 
 const cspHeader = `
     default-src 'self';
-    script-src 'self' 'unsafe-eval' 'unsafe-inline' https://challenges.cloudflare.com https://www.youtube.com https://www.youtube.com/iframe_api https://auth.privy.nounspace.com https://cdn.segment.com;
+    script-src 'self' 'unsafe-eval' 'unsafe-inline' https://challenges.cloudflare.com https://www.youtube.com https://www.youtube.com/iframe_api https://auth.privy.nounspace.com https://cdn.segment.com https://edge.fullstory.com https://rs.fullstory.com;
     style-src 'self' 'unsafe-inline' https://i.ytimg.com https://mint.highlight.xyz;
     media-src 'self' blob: data: https://stream.warpcast.com https://stream.farcaster.xyz https://res.cloudinary.com/ https://*.cloudflarestream.com https://*.b-cdn.net;
-    img-src 'self' blob: data: https:;
+    img-src 'self' blob: data: https: https://rs.fullstory.com;
     font-src 'self' https: data: blob: https://fonts.googleapis.com https://fonts.gstatic.com;
     object-src 'none';
     base-uri 'self';
@@ -39,6 +39,8 @@ const cspHeader = `
       https://auth.privy.io/api/v1/analytics_events
       https://cdn.segment.com
       https://api.segment.io
+      https://edge.fullstory.com
+      https://rs.fullstory.com
       https://api.imgbb.com
       https://api.goldsky.com
       https://api.reservoir.tools

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -23,16 +23,16 @@ We wrote this notice in plain English so you can quickly understand what data we
 | **Account basics** | Farcaster username, wallet address (public key) | You connect a wallet / log in with Farcaster | To recognise you, check token-gated access, show your profile |
 | **Public space settings** | Title, theme, layout, bio | You configure a Space | To display your Space to you and the public |
 | **Dashboard ("Homebase") settings** | Feeds you follow, layout, filters | Saved client-side and synced to us **encrypted** | So your private dashboard loads the same on any device |
-| **Usage analytics** | Page views, button clicks, feature usage, event timestamps, truncated/hashed device ID; **IP address used momentarily for geolocation lookup only** | Automatically via **Segment** and **Mixpanel** SDKs | To troubleshoot bugs, understand which features people like, and improve the app |
-| **Device & browser info** | Browser type, OS, screen size | Segment / Mixpanel | Same as above |
+| **Usage analytics** | Page views, button clicks, feature usage, event timestamps, truncated/hashed device ID; **IP address used momentarily for geolocation lookup only** | Automatically via **Segment**, **Mixpanel**, and **Fullstory** SDKs | To troubleshoot bugs, understand which features people like, and improve the app |
+| **Device & browser info** | Browser type, OS, screen size | Segment / Mixpanel / Fullstory | Same as above |
 **We do *not* collect:** real name, email, phone number, private keys, or full IP addresses stored alongside your profile.
 ---
 ## **3. Cookies & similar tech**
-We use first-party cookies (or local-storage tokens) plus Segment & Mixpanel cookies to remember you and measure product usage. You can clear or block these in your browser settings; the core app will still work but analytics accuracy drops.
+We use first-party cookies (or local-storage tokens) plus Segment, Mixpanel, and Fullstory cookies to remember you, measure product usage, and review anonymised session replays for UX improvements. You can clear or block these in your browser settings; the core app will still work but analytics accuracy drops.
 ---
 ## **4. How we use your data**
 1. **Provide the service** - load your Spaces, verify token-gated features.
-2. **Improve nounspace** - aggregate analytics help us see what breaks or what's popular.
+2. **Improve nounspace** - aggregate analytics and privacy-screened session replays (Segment, Mixpanel, Fullstory) help us see what breaks or what's popular.
 3. **Security & fraud prevention** - spot abuse or automated attacks.
 4. **Legal compliance** - keep records required by law or to defend our rights.
 We **do not** sell or rent your personal data.
@@ -42,6 +42,7 @@ We **do not** sell or rent your personal data.
 | ----- | ----- | ----- |
 | **Segment** (Twilio Inc.) | Event data, hashed device ID, truncated IP for routing | Routing analytics events to Mixpanel |
 | **Mixpanel Inc.** | Event data, hashed device ID, geolocation derived from IP (city/region), **no raw IP stored** | Product analytics |
+| **Fullstory Inc.** | Event data, hashed device ID, limited session replay snippets (with sensitive views masked) | Understand user flows and improve usability |
 | **Infrastructure providers** (e.g., cloud hosting) | Encrypted or pseudonymised data in transit/storage | Operate the platform |
 | **Law enforcement** | Data we hold, if legally compelled | Legal compliance |
 | **Community forks** | Open-source code *only*, never your analytics data | GPLv3 requirement |
@@ -55,11 +56,11 @@ We **do not** sell or rent your personal data.
 | Server logs | Up to 30 days for security, then deleted |
 ---
 ## **7. Your choices & rights**
-* **Opt-out of analytics:** Block cookies or use a tracker-blocking browser extension.
+* **Opt-out of analytics:** Block cookies or use a tracker-blocking browser extension; this disables Segment, Mixpanel, and Fullstory collection.
 * **Access / download your data:** DM a mod on Discord or email privacy@nounspace.com with your Farcaster username; we'll export what we have.
 * **Delete dashboard or Space:** Use in-app controls; dashboard data is wiped server-side, Space config removed from our DB (posts on Farcaster remain public).
 * **California & GDPR rights:** You can request deletion, correction, or a copy of your personal data. We honour valid requests within 30 days.
-* **Do-Not-Track signals:** We respect DNT headers by disabling Segment & Mixpanel when DNT = 1.
+* **Do-Not-Track signals:** We respect DNT headers by disabling Segment, Mixpanel, and Fullstory when DNT = 1.
 ---
 ## **8. Children's privacy**
 Nounspace is **not intended for children under 13**. If we learn someone under 13 is using nounspace, we'll disable analytics for that user and limit data processing to run the core service.
@@ -104,8 +105,8 @@ We wrote this notice in plain English so you can quickly understand what data we
 | **Account basics** | Farcaster username, wallet address (public key) | You connect a wallet / log in with Farcaster | To recognise you, check token‑gated access, show your profile |
 | **Public space settings** | Title, theme, layout, bio | You configure a Space | To display your Space to you and the public |
 | **Dashboard (“Homebase”) settings** | Feeds you follow, layout, filters | Saved client‑side and synced to us **encrypted** | So your private dashboard loads the same on any device |
-| **Usage analytics** | Page views, button clicks, feature usage, event timestamps, truncated/hashed device ID; **IP address used momentarily for geolocation lookup only** | Automatically via **Segment** and **Mixpanel** SDKs | To troubleshoot bugs, understand which features people like, and improve the app |
-| **Device & browser info** | Browser type, OS, screen size | Segment / Mixpanel | Same as above |
+| **Usage analytics** | Page views, button clicks, feature usage, event timestamps, truncated/hashed device ID; **IP address used momentarily for geolocation lookup only** | Automatically via **Segment**, **Mixpanel**, and **Fullstory** SDKs | To troubleshoot bugs, understand which features people like, and improve the app |
+| **Device & browser info** | Browser type, OS, screen size | Segment / Mixpanel / Fullstory | Same as above |
 
 **We do *not* collect:** real name, email, phone number, private keys, or full IP addresses stored alongside your profile.
 
@@ -113,7 +114,7 @@ We wrote this notice in plain English so you can quickly understand what data we
 
 ## **3. Cookies & similar tech**
 
-We use first‑party cookies (or local‑storage tokens) plus Segment & Mixpanel cookies to remember you and measure product usage. You can clear or block these in your browser settings; the core app will still work but analytics accuracy drops.
+We use first‑party cookies (or local‑storage tokens) plus Segment, Mixpanel, and Fullstory cookies to remember you, measure product usage, and review anonymised session replays for UX improvements. You can clear or block these in your browser settings; the core app will still work but analytics accuracy drops.
 
 ---
 
@@ -121,7 +122,7 @@ We use first‑party cookies (or local‑storage tokens) plus Segment & Mixpanel
 
 1. **Provide the service** – load your Spaces, verify token‑gated features.
 
-2. **Improve nounspace** – aggregate analytics help us see what breaks or what’s popular.
+2. **Improve nounspace** – aggregate analytics and privacy-screened session replays (Segment, Mixpanel, Fullstory) help us see what breaks or what’s popular.
 
 3. **Security & fraud prevention** – spot abuse or automated attacks.
 
@@ -137,6 +138,7 @@ We **do not** sell or rent your personal data.
 | ----- | ----- | ----- |
 | **Segment** (Twilio Inc.) | Event data, hashed device ID, truncated IP for routing | Routing analytics events to Mixpanel |
 | **Mixpanel Inc.** | Event data, hashed device ID, geolocation derived from IP (city/region), **no raw IP stored** | Product analytics |
+| **Fullstory Inc.** | Event data, hashed device ID, limited session replay snippets (with sensitive views masked) | Understand user flows and improve usability |
 | **Infrastructure providers** (e.g., cloud hosting) | Encrypted or pseudonymised data in transit/storage | Operate the platform |
 | **Law enforcement** | Data we hold, if legally compelled | Legal compliance |
 | **Community forks** | Open‑source code *only*, never your analytics data | GPLv3 requirement |
@@ -156,7 +158,7 @@ We **do not** sell or rent your personal data.
 
 ## **7. Your choices & rights**
 
-* **Opt‑out of analytics:** Block cookies or use a tracker‑blocking browser extension.
+* **Opt‑out of analytics:** Block cookies or use a tracker‑blocking browser extension; this disables Segment, Mixpanel, and Fullstory collection.
 
 * **Access / download your data:** DM a mod on Discord or email privacy@nounspace.com with your Farcaster username; we’ll export what we have.
 
@@ -164,7 +166,7 @@ We **do not** sell or rent your personal data.
 
 * **California & GDPR rights:** You can request deletion, correction, or a copy of your personal data. We honour valid requests within 30 days.
 
-* **Do‑Not‑Track signals:** We respect DNT headers by disabling Segment & Mixpanel when DNT = 1.
+* **Do‑Not‑Track signals:** We respect DNT headers by disabling Segment, Mixpanel, and Fullstory when DNT = 1.
 
 ---
 


### PR DESCRIPTION
## Summary
- allow Fullstory domains in the Content Security Policy for scripts, images, and connections
- document the use of Fullstory session replay analytics throughout the privacy notice tables and disclosures

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690915e2b8908325b30eb0af4aa5ed82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated Fullstory as an additional analytics provider alongside existing analytics platforms

* **Documentation**
  * Updated privacy policy to document Fullstory integration across analytics collection, cookies, session replays, data sharing practices, user opt-out options, and Do-Not-Track settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->