### PR TITLE
Normalize space handles for case-insensitive URLs

### DIFF
--- a/src/app/(spaces)/s/[handle]/layout.tsx
+++ b/src/app/(spaces)/s/[handle]/layout.tsx
@@ -18,14 +18,15 @@ export async function generateMetadata({
   params: Promise<{ handle: string; tabName?: string }> 
 }): Promise<Metadata> {
   const { handle, tabName: tabNameParam } = await params;
-  
+
   if (!handle) {
     return defaultMetadata; // Return default metadata if no handle
   }
 
+  const normalizedHandle = handle.toLowerCase();
   const userMetadata = await getUserMetadata(handle);
   if (!userMetadata) {
-    const baseMetadata = getUserMetadataStructure({ username: handle });
+    const baseMetadata = getUserMetadataStructure({ username: normalizedHandle });
     return {
       ...baseMetadata,
       other: { "fc:frame": JSON.stringify(defaultFrame) },
@@ -36,9 +37,10 @@ export async function generateMetadata({
   const tabName = tabNameParam ? decodeURIComponent(tabNameParam) : undefined;
   
   // Create Frame metadata for Farcaster with the correct path
-  const frameUrl = tabName 
-    ? `${WEBSITE_URL}/s/${handle}/${encodeURIComponent(tabName)}`
-    : `${WEBSITE_URL}/s/${handle}`;
+  const canonicalHandle = userMetadata?.username || normalizedHandle;
+  const frameUrl = tabName
+    ? `${WEBSITE_URL}/s/${canonicalHandle}/${encodeURIComponent(tabName)}`
+    : `${WEBSITE_URL}/s/${canonicalHandle}`;
     
   const displayName =
     userMetadata?.displayName || userMetadata?.username || handle;
@@ -47,7 +49,7 @@ export async function generateMetadata({
   const encodedDisplayName = encodeURIComponent(displayName || "");
   const encodedPfpUrl = encodeURIComponent(userMetadata?.pfpUrl || "");
   const encodedBio = encodeURIComponent(userMetadata?.bio || "");
-  const ogImageUrl = `${WEBSITE_URL}/api/metadata/spaces?username=${handle}&displayName=${encodedDisplayName}&pfpUrl=${encodedPfpUrl}&bio=${encodedBio}`;
+  const ogImageUrl = `${WEBSITE_URL}/api/metadata/spaces?username=${canonicalHandle}&displayName=${encodedDisplayName}&pfpUrl=${encodedPfpUrl}&bio=${encodedBio}`;
 
   const spaceFrame = {
     version: "next",

--- a/src/app/(spaces)/s/[handle]/utils.ts
+++ b/src/app/(spaces)/s/[handle]/utils.ts
@@ -13,9 +13,15 @@ export type Tab = {
 export const getUserMetadata = async (
   handle: string,
 ): Promise<UserMetadata | null> => {
+  const normalizedHandle = handle?.trim().toLowerCase();
+
+  if (!normalizedHandle) {
+    return null;
+  }
+
   try {
     // Check if response is valid before destructuring
-    const response = await neynar.lookupUserByUsername({ username: handle });
+    const response = await neynar.lookupUserByUsername({ username: normalizedHandle });
     
     // Validate response has expected structure
     if (!response || typeof response !== 'object' || !('user' in response)) {

--- a/tests/spaceHandleCase.test.ts
+++ b/tests/spaceHandleCase.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { getUserMetadata } from "@/app/(spaces)/s/[handle]/utils";
+import neynar from "@/common/data/api/neynar";
+
+vi.mock("@/common/data/api/neynar", () => ({
+  default: {
+    lookupUserByUsername: vi.fn(),
+  },
+}));
+
+describe("getUserMetadata", () => {
+  const lookupUserByUsername = vi.mocked(neynar.lookupUserByUsername);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("normalizes handles to lowercase before looking up user metadata", async () => {
+    lookupUserByUsername.mockResolvedValue({
+      user: {
+        fid: 123,
+        username: "moruf88",
+        display_name: "Moruf",
+        pfp_url: "https://example.com/pfp.png",
+        profile: {
+          bio: { text: "Testing bio" },
+        },
+      },
+    } as any);
+
+    const metadata = await getUserMetadata("MoRuf88");
+
+    expect(lookupUserByUsername).toHaveBeenCalledWith({ username: "moruf88" });
+    expect(metadata).toEqual({
+      fid: 123,
+      username: "moruf88",
+      displayName: "Moruf",
+      pfpUrl: "https://example.com/pfp.png",
+      bio: "Testing bio",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- normalize Farcaster handles before user metadata lookups so uppercase URLs resolve correctly
- update dynamic metadata generation to use canonical usernames for frame and OG URLs
- add a unit test covering case normalization in getUserMetadata

## Testing
- yarn lint
- yarn check-types
- yarn test tests/spaceHandleCase.test.ts

------
https://chatgpt.com/codex/tasks/task_e_690a93e444cc8325969d0c591928c686

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL consistency by normalizing handle references to lowercase for metadata lookups and link generation, ensuring consistent social sharing previews and frame URLs regardless of case usage.

* **Tests**
  * Added test coverage for handle normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->