### PR TITLE
Fix: Persist Selected Tab in Theme Editor

### DIFF
--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -182,7 +182,18 @@ export function ThemeSettingsEditor({
 }: ThemeSettingsEditorArgs) {
   const [showConfirmCancel, setShowConfirmCancel] = useState(false);
   const { mobilePreview, setMobilePreview } = useMobilePreview();
-  const [tabValue, setTabValue] = useState(mobilePreview ? ThemeEditorTab.MOBILE : ThemeEditorTab.SPACE);
+  // Persist selected tab
+  const LOCAL_STORAGE_KEY = 'themeEditorTab';
+  const getInitialTab = () => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem(LOCAL_STORAGE_KEY);
+      if (stored && Object.values(ThemeEditorTab).includes(stored as ThemeEditorTab)) {
+        return stored as ThemeEditorTab;
+      }
+    }
+    return mobilePreview ? ThemeEditorTab.MOBILE : ThemeEditorTab.SPACE;
+  };
+  const [tabValue, setTabValue] = useState<ThemeEditorTab>(getInitialTab());
   const [showVibeEditor, setShowVibeEditor] = useState(false);
 
   // Our theme and mobile app helpers
@@ -211,6 +222,10 @@ export function ThemeSettingsEditor({
   }, [getCurrentSpaceContext, theme]);
 
   useEffect(() => {
+    // Save to localStorage whenever tabValue changes
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(LOCAL_STORAGE_KEY, tabValue);
+    }
     setMobilePreview(tabValue === ThemeEditorTab.MOBILE);
   }, [tabValue, setMobilePreview]);
 
@@ -345,7 +360,11 @@ export function ThemeSettingsEditor({
 
             {/* Templates Dropdown */}
             <div className="min-w-0">
-              <Tabs value={tabValue} onValueChange={(value) => setTabValue(value as ThemeEditorTab)}>
+              <Tabs value={tabValue as string} onValueChange={(value) => {
+                if (Object.values(ThemeEditorTab).includes(value as ThemeEditorTab)) {
+                  setTabValue(value as ThemeEditorTab);
+                }
+              }}>
                 {/* controlled Tabs */}
                 <ThemeSettingsTabs activeTab={tabValue} onTabChange={setTabValue} />
                 {/* Fonts */}


### PR DESCRIPTION
### Problem
When switching between the "Mobile" and "Fidgets" tabs in the theme editor, the tab was reset to "Space" due to loss of local state when the component was unmounted and remounted.

### Solution
- The selected tab is now persisted in `localStorage` (key: `themeEditorTab`).
- Whenever the user changes the tab, the value is saved and restored when the editor is opened.
- This ensures that, when switching between "Mobile" and "Fidgets", the editor always opens on the last tab selected by the user.

### File changed
- `src/common/lib/theme/ThemeSettingsEditor.tsx`

### How it works
- The tab state is initialized from the value saved in `localStorage` or, if it does not exist, from the context (`mobilePreview`).
- The value is updated and saved in `localStorage` whenever the user changes the tab.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme editor tab selection is now saved and will be remembered when you return to the editor, restoring your preference automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->