### PR TITLE
Add owner address handling to chat fidget

### DIFF
--- a/src/app/(spaces)/t/[network]/[contractAddress]/utils.ts
+++ b/src/app/(spaces)/t/[network]/[contractAddress]/utils.ts
@@ -222,7 +222,12 @@ export const loadTokenSpacePageData = async (
   const castHash = tokenData?.clankerData?.cast_hash || "";
   const casterFid = String(tokenData?.clankerData?.requestor_fid || "");
   const isClankerToken = !!tokenData?.clankerData;
-  
+
+  const spaceOwnerAddress =
+    finalOwnerType === 'address' && finalOwnerId
+      ? finalOwnerId as Address
+      : "0x0000000000000000000000000000000000000000" as Address;
+
   // Create space config
   const config = {
     ...createInitialTokenSpaceConfigForAddress(
@@ -231,17 +236,15 @@ export const loadTokenSpacePageData = async (
       casterFid,
       symbol,
       isClankerToken,
-      network as EtherScanChainName
+      network as EtherScanChainName,
+      spaceOwnerAddress
     ),
     timestamp: new Date().toISOString(),
   };
-  
+
   // Convert ownerId to the appropriate type based on ownerIdType
   const spaceOwnerFid = finalOwnerType === 'fid' ? Number(finalOwnerId) : undefined;
-  const spaceOwnerAddress = finalOwnerType === 'address' && finalOwnerId ? 
-    finalOwnerId as Address : 
-    "0x0000000000000000000000000000000000000000" as Address;
-    
+
   return {
     spaceId: internalData.spaceId,
     spaceName,

--- a/src/common/components/organisms/FidgetSettingsEditor.tsx
+++ b/src/common/components/organisms/FidgetSettingsEditor.tsx
@@ -66,6 +66,12 @@ export const FidgetSettingsRow: React.FC<FidgetSettingsRowProps> = ({
 }) => {
   const InputComponent = field.inputSelector;
   const isValid = !field.validator || field.validator(value);
+  const errorMessage =
+    !isValid && field.errorMessage
+      ? typeof field.errorMessage === "function"
+        ? field.errorMessage(value)
+        : field.errorMessage
+      : undefined;
 
   return (
     <div
@@ -95,7 +101,7 @@ export const FidgetSettingsRow: React.FC<FidgetSettingsRowProps> = ({
           </TooltipProvider>
         )}
       </div>
-      <div>
+      <div className="flex flex-col gap-1">
         <InputComponent
           id={id}
           value={value}
@@ -105,6 +111,11 @@ export const FidgetSettingsRow: React.FC<FidgetSettingsRowProps> = ({
             !isValid && "border-red-500"
           )}
         />
+        {errorMessage && (
+          <p className="text-xs text-red-500" role="alert">
+            {errorMessage}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/src/common/fidgets/index.d.ts
+++ b/src/common/fidgets/index.d.ts
@@ -51,6 +51,7 @@ export type FidgetFieldConfig<S extends FidgetSettings = FidgetSettings> = {
   readonly displayName?: string;
   readonly displayNameHint?: string;
   readonly validator?: (value) => boolean;
+  readonly errorMessage?: string | ((value: any) => string);
   readonly inputSelector:
     | typeof TextInput
     | typeof ColorSelector

--- a/src/config/nouns/initialSpaces/initialProposalSpace.ts
+++ b/src/config/nouns/initialSpaces/initialProposalSpace.ts
@@ -61,22 +61,23 @@ export const createInitalProposalSpaceConfigForProposalId = (
       fidgetType: "iframe",
       id: "iframe:1afc071b-ce6b-4527-9419-f2e057a9fb0a",
     },
-    "iframe:ffb3cd56-3203-4b94-b842-adab9a7eabc9": {
+    "Chat:ffb3cd56-3203-4b94-b842-adab9a7eabc9": {
       config: {
         editable: true,
         data: {},
         settings: {
-          url: `https://chat-fidget.vercel.app/?room=prop%20${proposalId}%20chat&owner=${proposerAddress}`,
-          showOnMobile: true,
-          customMobileDisplayName: "Chat",
           background: "var(--user-theme-fidget-background)",
-          fidgetBorderWidth: "var(--user-theme-fidget-border-width)",
+          customMobileDisplayName: "Chat",
           fidgetBorderColor: "var(--user-theme-fidget-border-color)",
+          fidgetBorderWidth: "var(--user-theme-fidget-border-width)",
           fidgetShadow: "var(--user-theme-fidget-shadow)",
+          roomName: `prop ${proposalId} chat`,
+          roomOwnerAddress: proposerAddress,
+          showOnMobile: true,
         },
       },
-      fidgetType: "iframe",
-      id: "iframe:ffb3cd56-3203-4b94-b842-adab9a7eabc9",
+      fidgetType: "Chat",
+      id: "Chat:ffb3cd56-3203-4b94-b842-adab9a7eabc9",
     },
   };
 
@@ -132,7 +133,7 @@ export const createInitalProposalSpaceConfigForProposalId = (
           h: 4,
           x: 4,
           y: 6,
-          i: "iframe:ffb3cd56-3203-4b94-b842-adab9a7eabc9",
+          i: "Chat:ffb3cd56-3203-4b94-b842-adab9a7eabc9",
           minW: 2,
           maxW: 36,
           minH: 2,

--- a/src/config/nouns/initialSpaces/initialTokenSpace.ts
+++ b/src/config/nouns/initialSpaces/initialTokenSpace.ts
@@ -14,6 +14,7 @@ export const createInitialTokenSpaceConfigForAddress = (
   symbol: string,
   isClankerToken: boolean,
   network: EtherScanChainName = "base",
+  ownerAddress?: Address,
 ): Omit<SpaceConfig, "isEditable"> => {
   const config = cloneDeep(INITIAL_SPACE_CONFIG_EMPTY);
 
@@ -152,6 +153,7 @@ export const createInitialTokenSpaceConfigForAddress = (
           fidgetBorderWidth: "var(--user-theme-fidget-border-width)",
           fidgetShadow: "var(--user-theme-fidget-shadow)",
           roomName: address,
+          roomOwnerAddress: ownerAddress ?? "",
         },
       },
       fidgetType: "Chat",


### PR DESCRIPTION
## Summary
- add a Room Owner Address setting to the chat fidget with validation, tooltip guidance, and owner query parameter support
- surface field-level validation errors in the settings editor so invalid Ethereum addresses show an inline message
- default token space chat settings now include the resolved owner address when generating configs

## Testing
- yarn lint *(fails: workspace package missing from lockfile in this environment)*
- yarn check-types *(fails: workspace package missing from lockfile in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_690cf6caae5c83259dc25bfa7474c8c0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Room owner address configuration available for chat rooms.
  * Chat-based room widget introduced to replace the previous iframe-based view.

* **Improvements**
  * Inline per-field validation messages for form inputs.
  * Token space ownership handling consolidated and improved in configuration.
  * Field configuration extended to support custom (static or computed) error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->