### PR TITLE
Fix code-based web embed reloads

### DIFF
--- a/src/fidgets/ui/IFrame.tsx
+++ b/src/fidgets/ui/IFrame.tsx
@@ -363,6 +363,31 @@ const IFrame: React.FC<FidgetArgs<IFrameFidgetSettings>> = ({
     setIframelyEmbedAttributes(parseIframeAttributes(embedInfo.iframelyHtml));
   }, [embedInfo?.iframelyHtml]);
 
+  const iframelyMiniAppConfig = useMemo(() => {
+    if (!isMiniAppEnvironment || !iframelyEmbedAttributes?.src) {
+      return undefined;
+    }
+
+    if (!isValidHttpUrl(iframelyEmbedAttributes.src)) {
+      return null;
+    }
+
+    try {
+      const safeSrc = new URL(iframelyEmbedAttributes.src).toString();
+      return {
+        safeSrc,
+        bootstrapDoc: createMiniAppBootstrapSrcDoc(safeSrc),
+        allowFullScreen: "allowfullscreen" in iframelyEmbedAttributes,
+        sandboxRules: ensureSandboxRules(iframelyEmbedAttributes.sandbox),
+        widthAttr: iframelyEmbedAttributes.width,
+        heightAttr: iframelyEmbedAttributes.height,
+      };
+    } catch (error) {
+      console.warn("Rejected unsupported IFramely iframe src", error);
+      return null;
+    }
+  }, [isMiniAppEnvironment, iframelyEmbedAttributes]);
+
   const isValid = isValidHttpUrl(debouncedUrl);
   const sanitizedUrl = useSafeUrl(debouncedUrl);
   const transformedUrl = transformUrl(sanitizedUrl || "");
@@ -719,30 +744,6 @@ const IFrame: React.FC<FidgetArgs<IFrameFidgetSettings>> = ({
   }
 
   const iframelyEmbedSrc = iframelyEmbedAttributes?.src ?? null;
-  const iframelyMiniAppConfig = useMemo(() => {
-    if (!isMiniAppEnvironment || !iframelyEmbedAttributes?.src) {
-      return undefined;
-    }
-
-    if (!isValidHttpUrl(iframelyEmbedAttributes.src)) {
-      return null;
-    }
-
-    try {
-      const safeSrc = new URL(iframelyEmbedAttributes.src).toString();
-      return {
-        safeSrc,
-        bootstrapDoc: createMiniAppBootstrapSrcDoc(safeSrc),
-        allowFullScreen: "allowfullscreen" in iframelyEmbedAttributes,
-        sandboxRules: ensureSandboxRules(iframelyEmbedAttributes.sandbox),
-        widthAttr: iframelyEmbedAttributes.width,
-        heightAttr: iframelyEmbedAttributes.height,
-      };
-    } catch (error) {
-      console.warn("Rejected unsupported IFramely iframe src", error);
-      return null;
-    }
-  }, [isMiniAppEnvironment, iframelyEmbedAttributes]);
 
   if (!embedInfo.directEmbed && embedInfo.iframelyHtml) {
     if (isMiniAppEnvironment && iframelyEmbedSrc && iframelyEmbedAttributes) {

--- a/src/fidgets/ui/IFrame.tsx
+++ b/src/fidgets/ui/IFrame.tsx
@@ -8,7 +8,7 @@ import { useIsMobile } from "@/common/lib/hooks/useIsMobile";
 import { debounce } from "lodash";
 import { isValidHttpUrl } from "@/common/lib/utils/url";
 import { defaultStyleFields, ErrorWrapper, transformUrl, WithMargin } from "@/fidgets/helpers";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import DOMPurify from "isomorphic-dompurify";
 import { BsCloud, BsCloudFill } from "react-icons/bs";
 import { useMiniApp } from "@/common/utils/useMiniApp";
@@ -317,9 +317,6 @@ const IFrame: React.FC<FidgetArgs<IFrameFidgetSettings>> = ({
   const [iframelyEmbedAttributes, setIframelyEmbedAttributes] =
     useState<IframeAttributeMap | null>(null);
 
-  const sanitizedEmbedContainerRef = useRef<HTMLDivElement | null>(null);
-  const iframelyEmbedContainerRef = useRef<HTMLDivElement | null>(null);
-
   const sanitizedEmbedScript = useMemo(() => {
     if (!embedScript) return null;
     const clean = DOMPurify.sanitize(embedScript, {
@@ -337,6 +334,14 @@ const IFrame: React.FC<FidgetArgs<IFrameFidgetSettings>> = ({
     });
     return clean.trim() ? clean : null;
   }, [embedScript]);
+
+  const sanitizedEmbedMarkup = useMemo(
+    () =>
+      sanitizedEmbedScript
+        ? ({ __html: sanitizedEmbedScript } as { __html: string })
+        : undefined,
+    [sanitizedEmbedScript],
+  );
 
   useEffect(() => {
     debouncedSetUrl(url);
@@ -394,32 +399,13 @@ const IFrame: React.FC<FidgetArgs<IFrameFidgetSettings>> = ({
   // Scale value is set from size prop
   const _scaleValue = size;
 
-  useEffect(() => {
-    if (!sanitizedEmbedContainerRef.current) {
-      return;
-    }
-
-    if (!sanitizedEmbedScript) {
-      sanitizedEmbedContainerRef.current.innerHTML = "";
-      return;
-    }
-
-    sanitizedEmbedContainerRef.current.innerHTML = sanitizedEmbedScript;
-  }, [sanitizedEmbedScript]);
-
-  useEffect(() => {
-    if (!iframelyEmbedContainerRef.current) {
-      return;
-    }
-
-    const html = embedInfo?.iframelyHtml;
-    if (!html) {
-      iframelyEmbedContainerRef.current.innerHTML = "";
-      return;
-    }
-
-    iframelyEmbedContainerRef.current.innerHTML = html;
-  }, [embedInfo?.iframelyHtml]);
+  const iframelyEmbedMarkup = useMemo(
+    () =>
+      embedInfo?.iframelyHtml
+        ? ({ __html: embedInfo.iframelyHtml } as { __html: string })
+        : undefined,
+    [embedInfo?.iframelyHtml],
+  );
 
 
   useEffect(() => {
@@ -551,7 +537,7 @@ const IFrame: React.FC<FidgetArgs<IFrameFidgetSettings>> = ({
 
     return (
       <div
-        ref={sanitizedEmbedContainerRef}
+        dangerouslySetInnerHTML={sanitizedEmbedMarkup}
         style={{ overflow: "hidden", width: "100%", height: "100%" }}
       />
     );
@@ -750,7 +736,7 @@ const IFrame: React.FC<FidgetArgs<IFrameFidgetSettings>> = ({
       if (iframelyMiniAppConfig === null) {
         return (
           <div
-            ref={iframelyEmbedContainerRef}
+            dangerouslySetInnerHTML={iframelyEmbedMarkup}
             style={{ overflow: "hidden", width: "100%", height: "100%" }}
           />
         );
@@ -799,7 +785,7 @@ const IFrame: React.FC<FidgetArgs<IFrameFidgetSettings>> = ({
 
     return (
       <div
-        ref={iframelyEmbedContainerRef}
+        dangerouslySetInnerHTML={iframelyEmbedMarkup}
         style={{ overflow: "hidden", width: "100%", height: "100%" }}
       />
     );


### PR DESCRIPTION
I noticed that websites embedded in the web embed fidget via the Code setting (embed script) will re-render excessively (including every time you enter/exit customization mode). This fixes

## Summary
- stop iframe code embeds from re-rendering unless the embed script changes by directly managing the embedded markup
- memoize the mini app bootstrap docs for code and IFramely embeds so the iframe srcDoc stays stable between view mode toggles

## Testing
- yarn lint *(fails: workspace package missing because dependencies are not installed)*
- yarn install *(fails: RequestError 504 while fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_690d050dbad48325aa0c7b74b48d0d04

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Safer embed rendering in mini-app contexts with validated mini-app bootstrap documents and unified handling for direct and third-party embeds.
* **Bug Fixes**
  * Improved validation, sanitization and safe HTML insertion for embeds; added URL validation and debounced fetching.
  * Added a 1-hour cache for embed responses to reduce load and speed display.
* **UX**
  * Clear error state when an embed source is disallowed and safer fallbacks for unsupported embeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->