### PR TITLE
Handle settlement fetch reverts without logging noise

### DIFF
--- a/src/fidgets/nouns-home/NounsHomeFidget.tsx
+++ b/src/fidgets/nouns-home/NounsHomeFidget.tsx
@@ -16,6 +16,7 @@ import {
 } from "wagmi";
 import { mainnet } from "wagmi/chains";
 import { simulateContract, waitForTransactionReceipt } from "wagmi/actions";
+import { ContractFunctionExecutionError } from "viem";
 import AuctionHero from "./components/AuctionHero";
 import BidModal from "./components/BidModal";
 import StatsRow from "./components/StatsRow";
@@ -180,6 +181,13 @@ const useSettlements = (auction?: Auction) => {
         setHasMore(startId > 0);
         setPage(pageToLoad);
       } catch (error) {
+        if (error instanceof ContractFunctionExecutionError) {
+          // The contract reverts with "Internal error" when a requested range has
+          // no settlements yet. This is expected during gaps and does not impact
+          // the user experience, so we treat it as "no more data".
+          setHasMore(false);
+          return;
+        }
         console.error("Failed to load settlements", error);
       } finally {
         setIsLoading(false);


### PR DESCRIPTION
Removes the console error for the getSettlements contract error, which is occasionally expected and has no user-facing impact.

## Summary
- treat expected getSettlements contract reverts as exhausted history instead of logging errors
- stop requesting more pages when the contract indicates there is no additional settlement data

## Testing
- yarn lint *(fails: requires installing dependencies in lockfile)*
- yarn check-types *(fails: requires installing dependencies in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_690cf3f9dfe4832582db7d42c6c2046f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settlement data loading to gracefully handle edge cases where no data is available in the requested range, preventing unnecessary error messages during normal operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->