### PR TITLE
Update Clanker home tabs to Clank, Social, and Docs and apply baseline initial space configs

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/common/components/atoms/icons/RobotIcon.tsx
+++ b/src/common/components/atoms/icons/RobotIcon.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { RiRobot2Line } from "react-icons/ri";
+
+const RobotIcon = () => (
+  <RiRobot2Line 
+    className="w-6 h-6 text-gray-800 dark:text-white"
+    aria-hidden="true"
+  />
+);
+
+export default RobotIcon;
+

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -28,6 +28,7 @@ import { RiQuillPenLine } from "react-icons/ri";
 import HomeIcon from "../atoms/icons/HomeIcon";
 import NotificationsIcon from "../atoms/icons/NotificationsIcon";
 import RocketIcon from "../atoms/icons/RocketIcon";
+import RobotIcon from "../atoms/icons/RobotIcon";
 import SearchIcon from "../atoms/icons/SearchIcon";
 import ExploreIcon from "../atoms/icons/ExploreIcon";
 import LogoutIcon from "../atoms/icons/LogoutIcon";
@@ -136,6 +137,7 @@ const Navigation = React.memo(
       case 'explore': return ExploreIcon;
       case 'notifications': return NotificationsIcon;
       case 'space': return RocketIcon;
+      case 'robot': return RobotIcon;
       default: return HomeIcon;
     }
   }, []);

--- a/src/config/clanker/assets/icon.svg
+++ b/src/config/clanker/assets/icon.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="220px" height="110px" viewBox="0 0 220 110" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <title>Clanker Logo</title>
+    <desc>Three purple vertical bars of increasing height</desc>
+    <g id="bars" fill="#8B5CF6" fill-rule="evenodd">
+        <!-- Left bar (shortest) -->
+        <rect x="30" y="60" width="30" height="40" rx="4"/>
+        <!-- Middle bar (medium) -->
+        <rect x="95" y="40" width="30" height="60" rx="4"/>
+        <!-- Right bar (tallest) -->
+        <rect x="160" y="20" width="30" height="80" rx="4"/>
+    </g>
+</svg>
+

--- a/src/config/clanker/clanker.assets.ts
+++ b/src/config/clanker/clanker.assets.ts
@@ -1,6 +1,6 @@
 // Source images colocated with config, emitted by bundler
 import logo from './assets/logo.jpg';
-import icon from './assets/favicon.ico';
+import icon from './assets/icon.svg';
 import og from './assets/og.jpg';
 import applePng from './assets/apple.png';
 

--- a/src/config/clanker/clanker.home.ts
+++ b/src/config/clanker/clanker.home.ts
@@ -1,578 +1,384 @@
 export const clankerHomePage = {
-  defaultTab: "trading",
-  tabOrder: ["trading", "trending", "portfolio", "create", "analytics"],
+  defaultTab: "clank",
+  tabOrder: ["clank", "social", "docs"],
   tabs: {
-    trading: {
-      name: "trading",
-      displayName: "Trading",
-      layoutID: "clanker-trading-layout",
+    clank: {
+      name: "clank",
+      displayName: "Clank",
+      layoutID: "d99e0194-d32e-42da-94b9-d110097e7b05",
       layoutDetails: {
         layoutConfig: {
           layout: [
-            { w: 6, h: 4, x: 0, y: 0, i: "market-data" },
-            { w: 6, h: 4, x: 6, y: 0, i: "portfolio" },
-            { w: 4, h: 3, x: 0, y: 4, i: "swap" },
-            { w: 4, h: 3, x: 4, y: 4, i: "token-feed" },
-            { w: 4, h: 3, x: 8, y: 4, i: "token-gallery" },
-            { w: 12, h: 3, x: 0, y: 7, i: "token-links" }
+            {
+              h: 10,
+              i: "iframe:6b9e0d0a-30e4-4bf1-9d54-e96f465e63c6",
+              isBounded: false,
+              maxH: 36,
+              maxW: 36,
+              minH: 2,
+              minW: 2,
+              moved: false,
+              resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+              static: false,
+              w: 12,
+              x: 0,
+              y: 0
+            }
           ]
         },
         layoutFidget: "grid"
       },
       theme: {
-        id: "clanker-trading-theme",
-        name: "Clanker Trading Theme",
+        id: "Default",
+        name: "Default",
         properties: {
-          font: "Inter, system-ui, sans-serif",
-          fontColor: "#ffffff",
-          headingsFont: "Inter, system-ui, sans-serif",
-          headingsFontColor: "#00d4ff",
-          background: "linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%)",
+          background: "#ffffff",
           backgroundHTML: "",
-          musicURL: "",
-          fidgetBackground: "rgba(0, 212, 255, 0.1)",
+          fidgetBackground: "#ffffff",
+          fidgetBorderColor: "#eeeeee",
+          fidgetBorderRadius: "0px",
           fidgetBorderWidth: "1px",
-          fidgetBorderColor: "rgba(0, 212, 255, 0.3)",
-          fidgetShadow: "0 4px 20px rgba(0, 212, 255, 0.2)",
-          fidgetBorderRadius: "12px",
-          gridSpacing: "16"
+          fidgetShadow: "none",
+          font: "Inter",
+          fontColor: "#000000",
+          gridSpacing: "0",
+          headingsFont: "Inter",
+          headingsFontColor: "#000000",
+          musicURL: "https://www.youtube.com/watch?v=dMXlZ4y7OK4&t=1804"
         }
       },
       fidgetInstanceDatums: {
-        "market-data": {
-          id: "market-data",
-          fidgetType: "Market",
+        "iframe:6b9e0d0a-30e4-4bf1-9d54-e96f465e63c6": {
           config: {
             data: {},
             editable: true,
             settings: {
-              showMarketCap: true,
-              showVolume: true,
-              showPriceChange: true
+              background: "var(--user-theme-fidget-background)",
+              cropOffsetX: 0,
+              cropOffsetY: 0,
+              fidgetBorderColor: "var(--user-theme-fidget-border-color)",
+              fidgetBorderWidth: "var(--user-theme-fidget-border-width)",
+              fidgetShadow: "var(--user-theme-fidget-shadow)",
+              isScrollable: false,
+              showOnMobile: true,
+              url: "https://clanker.world"
             }
-          }
-        },
-        "portfolio": {
-          id: "portfolio",
-          fidgetType: "Portfolio",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showHoldings: true,
-              showValue: true,
-              showPnl: true
-            }
-          }
-        },
-        "swap": {
-          id: "swap",
-          fidgetType: "Swap",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showTokenSelection: true,
-              showAmountInput: true
-            }
-          }
-        },
-        "token-feed": {
-          id: "token-feed",
-          fidgetType: "feed",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showTokenDiscussions: true,
-              maxCasts: 10
-            }
-          }
-        },
-        "token-gallery": {
-          id: "token-gallery",
-          fidgetType: "gallery",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showTokenImages: true,
-              maxImages: 20
-            }
-          }
-        },
-        "token-links": {
-          id: "token-links",
-          fidgetType: "links",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showTokenLinks: true,
-              showExternalTools: true
-            }
-          }
-        }
-      },
-      fidgetTrayContents: [
-        "Market",
-        "Portfolio", 
-        "Swap",
-        "feed",
-        "gallery",
-        "links",
-        "text",
-        "iframe"
-      ],
-      isEditable: false,
-      timestamp: new Date().toISOString()
-    },
-    trending: {
-      name: "trending",
-      displayName: "Trending",
-      layoutID: "clanker-trending-layout",
-      layoutDetails: {
-        layoutConfig: {
-          layout: [
-            { w: 8, h: 6, x: 0, y: 0, i: "market-data" },
-            { w: 4, h: 6, x: 8, y: 0, i: "portfolio" },
-            { w: 6, h: 4, x: 0, y: 6, i: "token-feed" },
-            { w: 6, h: 4, x: 6, y: 6, i: "token-gallery" }
-          ]
-        },
-        layoutFidget: "grid"
-      },
-      theme: {
-        id: "clanker-trending-theme",
-        name: "Clanker Trending Theme",
-        properties: {
-          font: "Inter, system-ui, sans-serif",
-          fontColor: "#ffffff",
-          headingsFont: "Inter, system-ui, sans-serif",
-          headingsFontColor: "#ffd700",
-          background: "linear-gradient(135deg, #2d1b69 0%, #11998e 100%)",
-          backgroundHTML: "",
-          musicURL: "",
-          fidgetBackground: "rgba(255, 215, 0, 0.1)",
-          fidgetBorderWidth: "2px",
-          fidgetBorderColor: "#ffd700",
-          fidgetShadow: "0 4px 20px rgba(255, 215, 0, 0.2)",
-          fidgetBorderRadius: "12px",
-          gridSpacing: "16"
-        }
-      },
-      fidgetInstanceDatums: {
-        "market-data": {
-          id: "market-data",
-          fidgetType: "Market",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showTrending: true,
-              showVolume: true,
-              showPriceChange: true
-            }
-          }
-        },
-        "portfolio": {
-          id: "portfolio",
-          fidgetType: "Portfolio",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showTopHoldings: true,
-              showPerformance: true
-            }
-          }
-        },
-        "token-feed": {
-          id: "token-feed",
-          fidgetType: "feed",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showTrendingDiscussions: true,
-              maxCasts: 15
-            }
-          }
-        },
-        "token-gallery": {
-          id: "token-gallery",
-          fidgetType: "gallery",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showTrendingImages: true,
-              maxImages: 12
-            }
-          }
-        }
-      },
-      fidgetTrayContents: [
-        "Market",
-        "Portfolio",
-        "feed",
-        "gallery",
-        "links",
-        "Video",
-        "Rss"
-      ],
-      isEditable: false,
-      timestamp: new Date().toISOString()
-    },
-    portfolio: {
-      name: "portfolio",
-      displayName: "Portfolio",
-      layoutID: "clanker-portfolio-layout",
-      layoutDetails: {
-        layoutConfig: {
-          layout: [
-            { w: 6, h: 4, x: 0, y: 0, i: "portfolio" },
-            { w: 6, h: 4, x: 6, y: 0, i: "market-data" },
-            { w: 12, h: 4, x: 0, y: 4, i: "token-feed" },
-            { w: 6, h: 3, x: 0, y: 8, i: "swap" },
-            { w: 6, h: 3, x: 6, y: 8, i: "token-gallery" }
-          ]
-        },
-        layoutFidget: "grid"
-      },
-      theme: {
-        id: "clanker-portfolio-theme",
-        name: "Clanker Portfolio Theme",
-        properties: {
-          font: "Inter, system-ui, sans-serif",
-          fontColor: "#ffffff",
-          headingsFont: "Inter, system-ui, sans-serif",
-          headingsFontColor: "#00ff88",
-          background: "linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%)",
-          backgroundHTML: "",
-          musicURL: "",
-          fidgetBackground: "rgba(0, 255, 136, 0.1)",
-          fidgetBorderWidth: "1px",
-          fidgetBorderColor: "rgba(0, 255, 136, 0.3)",
-          fidgetShadow: "0 4px 20px rgba(0, 255, 136, 0.2)",
-          fidgetBorderRadius: "12px",
-          gridSpacing: "16"
-        }
-      },
-      fidgetInstanceDatums: {
-        "portfolio": {
-          id: "portfolio",
-          fidgetType: "Portfolio",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showTotalValue: true,
-              showPnl: true,
-              showAllocation: true
-            }
-          }
-        },
-        "market-data": {
-          id: "market-data",
-          fidgetType: "Market",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showPortfolioTokens: true,
-              showPriceChanges: true
-            }
-          }
-        },
-        "token-feed": {
-          id: "token-feed",
-          fidgetType: "feed",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showPortfolioDiscussions: true,
-              maxCasts: 20
-            }
-          }
-        },
-        "swap": {
-          id: "swap",
-          fidgetType: "Swap",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showQuickSwap: true,
-              showPortfolioTokens: true
-            }
-          }
-        },
-        "token-gallery": {
-          id: "token-gallery",
-          fidgetType: "gallery",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showPortfolioImages: true,
-              maxImages: 15
-            }
-          }
-        }
-      },
-      fidgetTrayContents: [
-        "Portfolio",
-        "Market",
-        "feed",
-        "Swap",
-        "gallery",
-        "links",
-        "Video",
-        "Chat"
-      ],
-      isEditable: false,
-      timestamp: new Date().toISOString()
-    },
-    create: {
-      name: "create",
-      displayName: "Create",
-      layoutID: "clanker-create-layout",
-      layoutDetails: {
-        layoutConfig: {
-          layout: [
-            { w: 8, h: 6, x: 0, y: 0, i: "text" },
-            { w: 4, h: 6, x: 8, y: 0, i: "links" },
-            { w: 6, h: 4, x: 0, y: 6, i: "gallery" },
-            { w: 6, h: 4, x: 6, y: 6, i: "feed" }
-          ]
-        },
-        layoutFidget: "grid"
-      },
-      theme: {
-        id: "clanker-create-theme",
-        name: "Clanker Create Theme",
-        properties: {
-          font: "Inter, system-ui, sans-serif",
-          fontColor: "#ffffff",
-          headingsFont: "Inter, system-ui, sans-serif",
-          headingsFontColor: "#ff6b6b",
-          background: "linear-gradient(135deg, #ff6b6b 0%, #4ecdc4 50%, #45b7d1 100%)",
-          backgroundHTML: "",
-          musicURL: "",
-          fidgetBackground: "rgba(255, 107, 107, 0.1)",
-          fidgetBorderWidth: "2px",
-          fidgetBorderColor: "#ff6b6b",
-          fidgetShadow: "0 6px 24px rgba(255, 107, 107, 0.3)",
-          fidgetBorderRadius: "16px",
-          gridSpacing: "16"
-        }
-      },
-      fidgetInstanceDatums: {
-        "text": {
-          id: "text",
-          fidgetType: "text",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              content: "# Create a Clanker\n\nWelcome to the Clankverse! Here you can create and launch your own tokens.\n\n## Getting Started\n1. Choose a token name and symbol\n2. Set initial supply and parameters\n3. Deploy your token\n4. Start trading!\n\nJoin the community and start building!",
-              showMarkdown: true
-            }
-          }
-        },
-        "links": {
-          id: "links",
-          fidgetType: "links",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showCreationTools: true,
-              showDocumentation: true,
-              showCommunity: true
-            }
-          }
-        },
-        "gallery": {
-          id: "gallery",
-          fidgetType: "gallery",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showRecentCreations: true,
-              showFeaturedTokens: true,
-              maxImages: 12
-            }
-          }
-        },
-        "feed": {
-          id: "feed",
-          fidgetType: "feed",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showCreationDiscussions: true,
-              showTips: true,
-              maxCasts: 15
-            }
-          }
-        }
-      },
-      fidgetTrayContents: [
-        "text",
-        "links",
-        "gallery",
-        "feed",
-        "iframe",
-        "Video",
-        "Chat",
-        "BuilderScore"
-      ],
-      isEditable: false,
-      timestamp: new Date().toISOString()
-    },
-    analytics: {
-      name: "analytics",
-      displayName: "Analytics",
-      layoutID: "clanker-analytics-layout",
-      layoutDetails: {
-        layoutConfig: {
-          layout: [
-            { w: 6, h: 4, x: 0, y: 0, i: "market-data" },
-            { w: 6, h: 4, x: 6, y: 0, i: "portfolio" },
-            { w: 4, h: 4, x: 0, y: 4, i: "rss" },
-            { w: 4, h: 4, x: 4, y: 4, i: "gallery" },
-            { w: 4, h: 4, x: 8, y: 4, i: "feed" },
-            { w: 12, h: 3, x: 0, y: 8, i: "iframe" }
-          ]
-        },
-        layoutFidget: "grid"
-      },
-      theme: {
-        id: "clanker-analytics-theme",
-        name: "Clanker Analytics Theme",
-        properties: {
-          font: "Inter, system-ui, sans-serif",
-          fontColor: "#ffffff",
-          headingsFont: "Inter, system-ui, sans-serif",
-          headingsFontColor: "#a8e6cf",
-          background: "linear-gradient(135deg, #667eea 0%, #764ba2 50%, #f093fb 100%)",
-          backgroundHTML: "",
-          musicURL: "",
-          fidgetBackground: "rgba(168, 230, 207, 0.15)",
-          fidgetBorderWidth: "1px",
-          fidgetBorderColor: "rgba(168, 230, 207, 0.4)",
-          fidgetShadow: "0 10px 40px rgba(168, 230, 207, 0.2)",
-          fidgetBorderRadius: "20px",
-          gridSpacing: "16"
-        }
-      },
-      fidgetInstanceDatums: {
-        "market-data": {
-          id: "market-data",
-          fidgetType: "Market",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showAnalytics: true,
-              showMarketCap: true,
-              showVolume: true
-            }
-          }
-        },
-        "portfolio": {
-          id: "portfolio",
-          fidgetType: "Portfolio",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showAnalytics: true,
-              showPerformance: true,
-              showMetrics: true
-            }
-          }
-        },
-        "rss": {
-          id: "rss",
-          fidgetType: "Rss",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showMarketNews: true,
-              showTokenNews: true,
-              maxItems: 10
-            }
-          }
-        },
-        "gallery": {
-          id: "gallery",
-          fidgetType: "gallery",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showAnalyticsCharts: true,
-              showDataVisualizations: true,
-              maxImages: 8
-            }
-          }
-        },
-        "feed": {
-          id: "feed",
-          fidgetType: "feed",
-          config: {
-            data: {},
-            editable: true,
-            settings: {
-              showAnalyticsDiscussions: true,
-              showMarketInsights: true,
-              maxCasts: 12
-            }
-          }
-        },
-        "iframe": {
-          id: "iframe",
+          },
           fidgetType: "iframe",
+          id: "iframe:6b9e0d0a-30e4-4bf1-9d54-e96f465e63c6"
+        }
+      },
+      fidgetTrayContents: [],
+      isEditable: false,
+      timestamp: "2025-11-06T20:36:32.148Z"
+    },
+    social: {
+      name: "social",
+      displayName: "Social",
+      layoutID: "e83d3c76-dcda-48e1-9537-8313403d38cc",
+      layoutDetails: {
+        layoutConfig: {
+          layout: [
+            {
+              w: 6,
+              h: 10,
+              x: 0,
+              y: 0,
+              i: "feed:d637f537-e22d-4f1d-88d8-4a62592571c3",
+              minW: 4,
+              maxW: 36,
+              minH: 2,
+              maxH: 36,
+              moved: false,
+              static: false,
+              resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+              isBounded: false
+            },
+            {
+              w: 6,
+              h: 6,
+              x: 6,
+              y: 0,
+              i: "feed:9c39372e-8c76-4c1e-9e15-6a5c6a609e24",
+              minW: 4,
+              maxW: 36,
+              minH: 2,
+              maxH: 36,
+              moved: false,
+              static: false,
+              resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+              isBounded: false
+            },
+            {
+              w: 2,
+              h: 4,
+              x: 10,
+              y: 6,
+              i: "links:c37310f3-d1af-45b6-8d30-9febd8cb9df1",
+              minW: 2,
+              maxW: 36,
+              minH: 2,
+              maxH: 36,
+              moved: false,
+              static: false,
+              resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+              isBounded: false
+            },
+            {
+              w: 4,
+              h: 4,
+              x: 6,
+              y: 6,
+              i: "feed:8343cda3-6319-4337-ba43-b053ebd5bb72",
+              minW: 4,
+              maxW: 36,
+              minH: 2,
+              maxH: 36,
+              moved: false,
+              static: false,
+              resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+              isBounded: false
+            }
+          ]
+        },
+        layoutFidget: "grid"
+      },
+      theme: {
+        id: "Clanker",
+        name: "Clanker",
+        properties: {
+          background: "rgba(135, 100, 210, 1)",
+          backgroundHTML: "",
+          fidgetBackground: "#ffffff",
+          fidgetBorderColor: "rgb(103, 41, 179)",
+          fidgetBorderRadius: "12px",
+          fidgetBorderWidth: "4px",
+          fidgetShadow: "0 4px 8px rgba(0,0,0,0.25)",
+          font: "Roboto Mono",
+          fontColor: "#000000",
+          gridSpacing: "23",
+          headingsFont: "Roboto",
+          headingsFontColor: "#000000",
+          musicURL: "https://www.youtube.com/watch?v=dMXlZ4y7OK4&t=1804"
+        }
+      },
+      fidgetInstanceDatums: {
+        "feed:8343cda3-6319-4337-ba43-b053ebd5bb72": {
           config: {
             data: {},
             editable: true,
             settings: {
-              showExternalAnalytics: true,
-              showTradingTools: true,
-              url: "https://analytics.clanker.world"
+              Xhandle: "thenounspace",
+              background: "var(--user-theme-fidget-background)",
+              channel: "",
+              feedType: "filter",
+              fidgetBorderColor: "var(--user-theme-fidget-border-color)",
+              fidgetBorderWidth: "var(--user-theme-fidget-border-width)",
+              fidgetShadow: "var(--user-theme-fidget-shadow)",
+              filterType: "fids",
+              fontColor: "var(--user-theme-font-color)",
+              fontFamily: "var(--user-theme-font)",
+              keyword: "clanker",
+              selectPlatform: {
+                icon: "/images/farcaster.jpeg",
+                name: "Farcaster"
+              },
+              showOnMobile: true,
+              style: "light",
+              username: "clanker",
+              users: ""
             }
-          }
+          },
+          fidgetType: "feed",
+          id: "feed:8343cda3-6319-4337-ba43-b053ebd5bb72"
+        },
+        "feed:9c39372e-8c76-4c1e-9e15-6a5c6a609e24": {
+          config: {
+            data: {},
+            editable: true,
+            settings: {
+              Xhandle: "thenounspace",
+              background: "var(--user-theme-fidget-background)",
+              channel: "clanker",
+              feedType: "filter",
+              fidgetBorderColor: "var(--user-theme-fidget-border-color)",
+              fidgetBorderWidth: "var(--user-theme-fidget-border-width)",
+              fidgetShadow: "var(--user-theme-fidget-shadow)",
+              filterType: "channel_id",
+              fontColor: "var(--user-theme-font-color)",
+              fontFamily: "var(--user-theme-font)",
+              keyword: "",
+              selectPlatform: {
+                icon: "/images/farcaster.jpeg",
+                name: "Farcaster"
+              },
+              showOnMobile: true,
+              style: "light",
+              username: "",
+              users: ""
+            }
+          },
+          fidgetType: "feed",
+          id: "feed:9c39372e-8c76-4c1e-9e15-6a5c6a609e24"
+        },
+        "feed:d637f537-e22d-4f1d-88d8-4a62592571c3": {
+          config: {
+            data: {},
+            editable: true,
+            settings: {
+              Xhandle: "thenounspace",
+              background: "var(--user-theme-fidget-background)",
+              channel: "clankers",
+              feedType: "filter",
+              fidgetBorderColor: "var(--user-theme-fidget-border-color)",
+              fidgetBorderWidth: "var(--user-theme-fidget-border-width)",
+              fidgetShadow: "var(--user-theme-fidget-shadow)",
+              filterType: "channel_id",
+              fontColor: "var(--user-theme-font-color)",
+              fontFamily: "var(--user-theme-font)",
+              keyword: "",
+              selectPlatform: {
+                icon: "/images/farcaster.jpeg",
+                name: "Farcaster"
+              },
+              showOnMobile: true,
+              style: "light",
+              username: "",
+              users: ""
+            }
+          },
+          fidgetType: "feed",
+          id: "feed:d637f537-e22d-4f1d-88d8-4a62592571c3"
+        },
+        "links:c37310f3-d1af-45b6-8d30-9febd8cb9df1": {
+          config: {
+            data: {},
+            editable: true,
+            settings: {
+              DescriptionColor: "var(--user-theme-font-color)",
+              HeaderColor: "var(--user-theme-headings-font-color)",
+              background: "var(--user-theme-fidget-background)",
+              css: "",
+              fidgetBorderColor: "var(--user-theme-fidget-border-color)",
+              fidgetBorderWidth: "var(--user-theme-fidget-border-width)",
+              fidgetShadow: "var(--user-theme-fidget-shadow)",
+              fontFamily: "Theme Font",
+              headingsFontFamily: "var(--user-theme-headings-font)",
+              itemBackground: "var(--user-theme-fidget-background)",
+              links: [
+                {
+                  avatar:
+                    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA/0lEQVR4AbXPIazCMACE4d+L2qoZFEGSIGcRc/gJJB5XMzGJmK9EN0HMi+qaibkKVF1txdQe4g0YzPK5yyWXHL9TaPNQ89LojH87N1rbJcXkMF4Fk31UMrf34hm14KUeoQxGArALHTMuQD2cAWQfJXOpgTbksGr9ng8qluShJTPhyCdx63POg7rEim95ZyR68I1ggQpnCEGwyPicw6hZtPEGmnhkycqOio1zm6XuFtyw5XDXfGvuau0dXHzJp8pfBPuhIXO9ZK5ILUCdSvLYMpc6ASBtl3EaC97I4KaFaOCaBE9Zn5jUsVqR2vcTJZO1DdbGoZryVp94Ka/mQfE7f2T3df0WBhLDAAAAAElFTkSuQmCC",
+                  description: "",
+                  text: "@clankeronbase",
+                  url: "https://x.com/clankeronbase"
+                },
+                {
+                  avatar: "/images/farcaster.jpeg",
+                  description: "",
+                  text: "@clanker",
+                  url: "https://farcaster.xyz/clanker"
+                },
+                {
+                  avatar: "/images/farcaster.jpeg",
+                  description: "",
+                  text: "/clanker",
+                  url: "https://farcaster.xyz/~/channel/clanker"
+                },
+                {
+                  avatar: "/images/farcaster.jpeg",
+                  description: "",
+                  text: "/clankers",
+                  url: "https://farcaster.xyz/~/channel/clankers"
+                }
+              ],
+              showOnMobile: true,
+              title: "",
+              viewMode: "list"
+            }
+          },
+          fidgetType: "links",
+          id: "links:c37310f3-d1af-45b6-8d30-9febd8cb9df1"
         }
       },
-      fidgetTrayContents: [
-        "Market",
-        "Portfolio",
-        "Rss",
-        "gallery",
-        "feed",
-        "iframe",
-        "Video",
-        "Chat"
-      ],
+      fidgetTrayContents: [],
       isEditable: false,
-      timestamp: new Date().toISOString()
-    }
-  },
-  layout: {
-    defaultLayoutFidget: "grid",
-    gridSpacing: 16,
-    theme: {
-      background: "linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%)",
-      fidgetBackground: "rgba(255, 255, 255, 0.1)",
-      font: "Inter, system-ui, sans-serif",
-      fontColor: "#ffffff"
+      timestamp: "2025-11-06T20:36:45.381Z"
+    },
+    docs: {
+      name: "docs",
+      displayName: "Docs",
+      layoutID: "60a345e4-6c97-4ce8-8bd8-daa3965a576a",
+      layoutDetails: {
+        layoutConfig: {
+          layout: [
+            {
+              w: 12,
+              h: 10,
+              x: 0,
+              y: 0,
+              i: "iframe:1c3fcd3d-7c7d-4c3f-920c-8ab48460eb4e",
+              minW: 2,
+              maxW: 36,
+              minH: 2,
+              maxH: 36,
+              moved: false,
+              static: false,
+              resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+              isBounded: false
+            }
+          ]
+        },
+        layoutFidget: "grid"
+      },
+      theme: {
+        id: "Default",
+        name: "Default",
+        properties: {
+          background: "#ffffff",
+          backgroundHTML: "",
+          fidgetBackground: "#ffffff",
+          fidgetBorderColor: "#eeeeee",
+          fidgetBorderRadius: "0px",
+          fidgetBorderWidth: "1px",
+          fidgetShadow: "none",
+          font: "Inter",
+          fontColor: "#000000",
+          gridSpacing: "0",
+          headingsFont: "Inter",
+          headingsFontColor: "#000000",
+          musicURL: "https://www.youtube.com/watch?v=dMXlZ4y7OK4&t=1804"
+        }
+      },
+      fidgetInstanceDatums: {
+        "iframe:1c3fcd3d-7c7d-4c3f-920c-8ab48460eb4e": {
+          config: {
+            data: {},
+            editable: true,
+            settings: {
+              background: "var(--user-theme-fidget-background)",
+              cropOffsetX: 0,
+              cropOffsetY: 0,
+              embedScript: `<iframe src="https://clanker.gitbook.io/clanker-documentation"
+        width="100%"
+        height="100%"
+        allowfullscreen>
+</iframe>`,
+              fidgetBorderColor: "var(--user-theme-fidget-border-color)",
+              fidgetBorderWidth: "var(--user-theme-fidget-border-width)",
+              fidgetShadow: "var(--user-theme-fidget-shadow)",
+              isScrollable: false,
+              showOnMobile: true,
+              url: ""
+            }
+          },
+          fidgetType: "iframe",
+          id: "iframe:1c3fcd3d-7c7d-4c3f-920c-8ab48460eb4e"
+        }
+      },
+      fidgetTrayContents: [],
+      isEditable: false,
+      timestamp: "2025-11-06T20:37:03.565Z"
     }
   }
 };

--- a/src/config/clanker/clanker.home.ts
+++ b/src/config/clanker/clanker.home.ts
@@ -61,7 +61,7 @@ export const clankerHomePage = {
               fidgetShadow: "var(--user-theme-fidget-shadow)",
               isScrollable: false,
               showOnMobile: true,
-              url: "https://clanker.world"
+              url: "https://www.clanker.world"
             }
           },
           fidgetType: "iframe",

--- a/src/config/clanker/clanker.navigation.ts
+++ b/src/config/clanker/clanker.navigation.ts
@@ -4,6 +4,7 @@ export const clankerNavigation: NavigationConfig = {
   items: [
     { id: 'home', label: 'Home', href: '/home', icon: 'home' },
     { id: 'notifications', label: 'Notifications', href: '/notifications', icon: 'notifications', requiresAuth: true },
+    { id: 'clanker-token', label: '$CLANKER', href: '/t/base/0x1bc0c42215582d5a085795f4badbac3ff36d1bcb/Profile', icon: 'robot' },
   ]
 };
 

--- a/src/config/clanker/initialSpaces/index.ts
+++ b/src/config/clanker/initialSpaces/index.ts
@@ -1,5 +1,6 @@
+// Export the initial space creators from nouns config
 export { default as createInitialProfileSpaceConfigForFid } from './initialProfileSpace';
 export { default as createInitialChannelSpaceConfig } from './initialChannelSpace';
 export { default as createInitialTokenSpaceConfigForAddress } from './initialTokenSpace';
-export { default as createInitialProposalSpaceConfigForProposalId } from './initialProposalSpace';
+export { default as createInitalProposalSpaceConfigForProposalId } from './initialProposalSpace';
 export { default as INITIAL_HOMEBASE_CONFIG } from './initialHomebase';

--- a/src/config/clanker/initialSpaces/initialChannelSpace.ts
+++ b/src/config/clanker/initialSpaces/initialChannelSpace.ts
@@ -1,75 +1,55 @@
 import { SpaceConfig } from "@/app/(spaces)/Space";
+import { FilterType, FeedType } from "@neynar/nodejs-sdk/build/api";
 import { cloneDeep } from "lodash";
 import { getLayoutConfig } from "@/common/utils/layoutFormatUtils";
 import { INITIAL_SPACE_CONFIG_EMPTY } from "../../initialSpaceConfig";
-import { FilterType, FeedType } from "@neynar/nodejs-sdk/build/api";
+
+const INITIAL_CHANNEL_SPACE_CONFIG = cloneDeep(INITIAL_SPACE_CONFIG_EMPTY);
+INITIAL_CHANNEL_SPACE_CONFIG.tabNames = ["Channel"];
 
 const createInitialChannelSpaceConfig = (
-	channelId: string,
+  channelId: string,
 ): Omit<SpaceConfig, "isEditable"> => {
-	const config = cloneDeep(INITIAL_SPACE_CONFIG_EMPTY);
+  const config = cloneDeep(INITIAL_CHANNEL_SPACE_CONFIG);
 
-	// Apply Clanker-specific theme defaults while preserving required UserTheme shape
-	config.theme = {
-		id: "clanker-channel-theme",
-		name: "Clanker Channel Theme",
-		properties: {
-			font: "Inter, system-ui, sans-serif",
-			fontColor: "#ffffff",
-			headingsFont: "Inter, system-ui, sans-serif",
-			headingsFontColor: "#00ff88",
-			background:
-				"linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%)",
-			backgroundHTML: "",
-			musicURL: "",
-			fidgetBackground: "#00ff88",
-			fidgetBorderWidth: "1px",
-			fidgetBorderColor: "#00ff88",
-			fidgetShadow: "0 4px 20px rgba(0, 255, 136, 0.2)",
-			fidgetBorderRadius: "12px",
-			gridSpacing: "16",
-		},
-	};
+  config.fidgetInstanceDatums = {
+    "feed:channel": {
+      config: {
+        editable: false,
+        settings: {
+          feedType: FeedType.Filter,
+          filterType: FilterType.ChannelId,
+          channel: channelId,
+        },
+        data: {},
+      },
+      fidgetType: "feed",
+      id: "feed:channel",
+    },
+  };
 
-	// Minimal initial fidget: a channel feed similar to nouns' channel space
-	config.fidgetInstanceDatums = {
-		"feed:channel": {
-			config: {
-				editable: false,
-				settings: {
-					feedType: FeedType.Filter,
-					filterType: FilterType.ChannelId,
-					channel: channelId,
-				},
-				data: {},
-			},
-			fidgetType: "feed",
-			id: "feed:channel",
-		},
-	};
+  const layoutItems = [
+    {
+      w: 6,
+      h: 8,
+      x: 0,
+      y: 0,
+      i: "feed:channel",
+      minW: 4,
+      maxW: 20,
+      minH: 6,
+      maxH: 12,
+      moved: false,
+      static: false,
+    },
+  ];
 
-	const layoutItems = [
-		{
-			w: 6,
-			h: 8,
-			x: 0,
-			y: 0,
-			i: "feed:channel",
-			minW: 4,
-			maxW: 20,
-			minH: 6,
-			maxH: 12,
-			moved: false,
-			static: false,
-		},
-	];
+  const layoutConfig = getLayoutConfig(config.layoutDetails);
+  layoutConfig.layout = layoutItems;
 
-	const layoutConfig = getLayoutConfig(config.layoutDetails);
-	layoutConfig.layout = layoutItems;
+  config.tabNames = ["Channel"];
 
-	config.tabNames = ["Channel"];
-
-	return config;
+  return config;
 };
 
 export default createInitialChannelSpaceConfig;

--- a/src/config/clanker/initialSpaces/initialHomebase.ts
+++ b/src/config/clanker/initialSpaces/initialHomebase.ts
@@ -1,157 +1,106 @@
 import { SpaceConfig } from "@/app/(spaces)/Space";
-import { cloneDeep } from "lodash";
-import { getLayoutConfig } from "@/common/utils/layoutFormatUtils";
-import { INITIAL_SPACE_CONFIG_EMPTY } from "../../initialSpaceConfig";
+import DEFAULT_THEME from "@/common/lib/theme/defaultTheme";
 
-const INITIAL_HOMEBASE_CONFIG: SpaceConfig = (() => {
-	const config = cloneDeep(INITIAL_SPACE_CONFIG_EMPTY);
+const tutorialText = `
+### 🖌️ Click the paintbrush in the bottom-left corner to open Customization Mode
 
-	config.theme = {
-		id: "clanker-homebase-theme",
-		name: "Clanker Homebase Theme",
-		properties: {
-			font: "Inter, system-ui, sans-serif",
-			fontColor: "#ffffff",
-			headingsFont: "Inter, system-ui, sans-serif",
-			headingsFontColor: "#a8e6cf",
-			background:
-				"linear-gradient(135deg, #667eea 0%, #764ba2 50%, #f093fb 100%)",
-			backgroundHTML: "",
-			musicURL: "",
-			fidgetBackground: "#a8e6cf",
-			fidgetBorderWidth: "1px",
-			fidgetBorderColor: "#a8e6cf",
-			fidgetShadow: "0 10px 40px rgba(168, 230, 207, 0.2)",
-			fidgetBorderRadius: "20px",
-			gridSpacing: "24",
-		},
-	};
+### Add Fidgets
+1. Click the blue **+** button.
+2. Drag a Fidget to an open spot on the grid.
+3. Click Save
 
-	config.fidgetInstanceDatums = {
-		"market-data": {
-			id: "market-data",
-			fidgetType: "Market",
-			config: {
-				data: {},
-				editable: true,
-				settings: {
-					showEcosystemOverview: true,
-					showMarketCap: true,
-					showVolume: true,
-				},
-			},
-		},
-		portfolio: {
-			id: "portfolio",
-			fidgetType: "Portfolio",
-			config: {
-				data: {},
-				editable: true,
-				settings: {
-					showEcosystemMetrics: true,
-					showPerformance: true,
-					showTrends: true,
-				},
-			},
-		},
-		rss: {
-			id: "rss",
-			fidgetType: "Rss",
-			config: {
-				data: {},
-				editable: true,
-				settings: {
-					showEcosystemNews: true,
-					showTokenNews: true,
-					maxItems: 8,
-				},
-			},
-		},
-		gallery: {
-			id: "gallery",
-			fidgetType: "gallery",
-			config: {
-				data: {},
-				editable: true,
-				settings: {
-					showEcosystemImages: true,
-					showDataVisualizations: true,
-					maxImages: 10,
-				},
-			},
-		},
-		feed: {
-			id: "feed",
-			fidgetType: "feed",
-			config: {
-				data: {},
-				editable: true,
-				settings: {
-					showEcosystemDiscussions: true,
-					showTrendingTopics: true,
-					maxCasts: 12,
-				},
-			},
-		},
-		links: {
-			id: "links",
-			fidgetType: "links",
-			config: {
-				data: {},
-				editable: true,
-				settings: {
-					showEcosystemLinks: true,
-					showExternalTools: true,
-				},
-			},
-		},
-		text: {
-			id: "text",
-			fidgetType: "text",
-			config: {
-				data: {},
-				editable: true,
-				settings: {
-					showEcosystemDescription: true,
-					showStats: true,
-				},
-			},
-		},
-		iframe: {
-			id: "iframe",
-			fidgetType: "iframe",
-			config: {
-				data: {},
-				editable: true,
-				settings: {
-					showEcosystemAnalytics: true,
-					url: "https://analytics.clanker.world",
-				},
-			},
-		},
-	};
+(after saving, scroll down here for more instructions)
 
-	const layoutItems = [
-		{ w: 6, h: 4, x: 0, y: 0, i: "market-data" },
-		{ w: 6, h: 4, x: 6, y: 0, i: "portfolio" },
-		{ w: 4, h: 3, x: 0, y: 4, i: "rss" },
-		{ w: 4, h: 3, x: 4, y: 4, i: "gallery" },
-		{ w: 4, h: 3, x: 8, y: 4, i: "feed" },
-		{ w: 8, h: 4, x: 0, y: 7, i: "links" },
-		{ w: 4, h: 4, x: 8, y: 7, i: "text" },
-		{ w: 12, h: 3, x: 0, y: 11, i: "iframe" },
-	];
+![Add Fidget2](https://space.mypinata.cloud/ipfs/bafkreiczpd2bzyoboj6uxr65kta5cmg3bziveq2nz5egx4fuxr2nmkthru)
 
-	const layoutConfig = getLayoutConfig(config.layoutDetails);
-	layoutConfig.layout = layoutItems;
+### Customize Fidgets
+1. From customization mode, click any Fidget on the grid to open its settings.
+2. Click 'Style' to customize a fidget's look. Any Fidget styles set to "Theme" inherit their look from the Tab's theme.  
 
-	config.tabNames = ["Homebase"];
+![EditFidget](https://space.mypinata.cloud/ipfs/bafybeihcjkbcljxr4ttgt6xcxmsc4m4qvw62hkolifmd3t5pdc7kvj5nji)
 
-	// Ensure required SpaceConfig field present and return full SpaceConfig
-	return {
-		...config,
-		isEditable: false,
-	};
-})();
+### Arrange Fidgets
+- **Move:** Drag from the center
+![move fidget](https://space.mypinata.cloud/ipfs/QmYWvdpdiyKwjVAqjhcFTBkiTUnc8rF4p2EGg3C4sTRsr6)
+- **Resize:** Drag from an edge or corner
+![Resize Fidget](https://space.mypinata.cloud/ipfs/bafybeifmssfizx5xjmmqyc6wwqxgs2xdhhbdtnvldtj276mfdul3eacmwu)
+- **Stash in Fidget Tray:** Click a fidget then click ⇱ to save it for later.
+![image](https://space.mypinata.cloud/ipfs/bafkreigy7ymnuwertvr6bn4bmwfe3vu3vvw4r6ekkzv6prs4zwlibsjtya)
+- **Delete:** Click a fidget then click X it to delete it forever.
+![image](https://space.mypinata.cloud/ipfs/bafkreieucvjlovm7wq5ftcvvvcv52sujnqqjwji5epoigb2ycumhmgrtfy)
+
+### Customize Theme
+- **Templates:** Select a pre-made Theme. Then, customize it further to make it your own.
+- **Style:** Set a background color for the Tab, or set the default styles for all Fidgets on the Tab.
+- **Fonts:** Set the default header and body fonts for Fidgets on the Tab.
+- **Code:** Add HTML/CSS to fully customize the Tab's background, or generate a custom background with a prompt. 
+
+![Edit Theme2](https://space.mypinata.cloud/ipfs/bafybeietizt4vgyaiv62ytn25ztanusjmbcw6iwm3v2gedcpipr6koxh3e)
+
+### Customize Music
+Add a soundtrack to each Tab. Search for or paste the link to any song or playlist on YouTube, or select a music NFT.
+
+![customize music](https://space.mypinata.cloud/ipfs/bafkreigtslrp3kjj42gp25bxd5nubs47qx22ivj3pkm3tc7j3fbqt3b5hy)
+
+### Homebase vs. Space
+**Your Space** is your public profile that everyone can see.
+**Your Homebase** is a private dashboard that only you can see.
+
+You can use the same tricks and Fidgets to customize them both. Use your **Homebase** to access the content, communities, and functionality you love, and use your **Space** to share the content and functionality you love with your friends.
+
+### Questions or feedback?
+
+Tag [@nounspacetom](https://nounspace.com/s/nounspacetom) in a cast or join our [Discord](https://discord.gg/H8EYnEmj6q).
+
+### Happy customizing!
+`;
+const onboardingFidgetID = "text:onboarding";
+const onboardingFidgetConfig = {
+  config: {
+    editable: true,
+    settings: {
+      title: "",
+      text: tutorialText,
+      urlColor: "blue",
+      fontFamily: "Londrina Solid",
+      fontColor: "#073b4c",
+      headingsFontFamily: "Londrina Solid",
+      headingsFontColor: "#2563ea",
+      backgroundColor: "#06d6a0",
+      borderColor: "#ffd166",
+    },
+    data: {},
+  },
+  fidgetType: "text",
+  id: onboardingFidgetID,
+};
+
+const layoutID = "";
+const INITIAL_HOMEBASE_CONFIG: SpaceConfig = {
+  layoutID,
+  layoutDetails: {
+    layoutConfig: {
+      layout: [
+        // Existing layouts can go here, e.g., feed, profile, etc.
+        {
+          w: 6,
+          h: 7,
+          x: 0,
+          y: 0,
+          i: onboardingFidgetID,
+          moved: false,
+          static: false,
+        },
+      ],
+    },
+    layoutFidget: "grid",
+  },
+  theme: DEFAULT_THEME,
+  fidgetInstanceDatums: {
+    [onboardingFidgetID]: onboardingFidgetConfig,
+  },
+  isEditable: false,
+  fidgetTrayContents: [],
+};
 
 export default INITIAL_HOMEBASE_CONFIG;

--- a/src/config/clanker/initialSpaces/initialProfileSpace.ts
+++ b/src/config/clanker/initialSpaces/initialProfileSpace.ts
@@ -1,127 +1,83 @@
 import { SpaceConfig } from "@/app/(spaces)/Space";
+import { FeedType, FilterType } from "@neynar/nodejs-sdk/build/api";
 import { cloneDeep } from "lodash";
 import { getLayoutConfig } from "@/common/utils/layoutFormatUtils";
 import { INITIAL_SPACE_CONFIG_EMPTY } from "../../initialSpaceConfig";
 
+// Set default tabNames for profile spaces
+const INITIAL_PROFILE_SPACE_CONFIG = cloneDeep(INITIAL_SPACE_CONFIG_EMPTY);
+INITIAL_PROFILE_SPACE_CONFIG.tabNames = ["Profile"];
+
 const createInitialProfileSpaceConfigForFid = (
-	fid: number,
+  fid: number,
+  username?: string,
 ): Omit<SpaceConfig, "isEditable"> => {
-	const config = cloneDeep(INITIAL_SPACE_CONFIG_EMPTY);
+  const config = cloneDeep(INITIAL_PROFILE_SPACE_CONFIG);
+  config.fidgetInstanceDatums = {
+    "feed:profile": {
+      config: {
+        editable: false,
+        settings: {
+          feedType: FeedType.Filter,
+          users: fid,
+          filterType: FilterType.Fids,
+        },
+        data: {},
+      },
+      fidgetType: "feed",
+      id: "feed:profile",
+    },
+    "Portfolio:cd627e89-d661-4255-8c4c-2242a950e93e": {
+      config: {
+        editable: false,
+        settings: {
+          trackType: "farcaster",
+          farcasterUsername: username ?? "",
+          walletAddresses: "",
+        },
+        data: {},
+      },
+      fidgetType: "Portfolio",
+      id: "Portfolio:cd627e89-d661-4255-8c4c-2242a950e93e",
+    },
+  };
+  const layoutItems = [
+    {
+      w: 6,
+      h: 8,
+      x: 0,
+      y: 0,
+      i: "feed:profile",
+      minW: 4,
+      maxW: 36,
+      minH: 6,
+      maxH: 36,
+      moved: false,
+      static: false,
+    },
+    {
+      w: 6,
+      h: 8,
+      x: 7,
+      y: 0,
+      i: "Portfolio:cd627e89-d661-4255-8c4c-2242a950e93e",
+      minW: 3,
+      maxW: 36,
+      minH: 3,
+      maxH: 36,
+      moved: false,
+      static: false,
+      }
+  ];
 
-	config.theme = {
-		id: "clanker-profile-theme",
-		name: "Clanker Profile Theme",
-		properties: {
-			font: "Inter, system-ui, sans-serif",
-			fontColor: "#ffffff",
-			headingsFont: "Inter, system-ui, sans-serif",
-			headingsFontColor: "#00d4ff",
-			background: "linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%)",
-			backgroundHTML: "",
-			musicURL: "",
-			fidgetBackground: "#00d4ff",
-			fidgetBorderWidth: "1px",
-			fidgetBorderColor: "#00d4ff",
-			fidgetShadow: "0 4px 20px rgba(0, 212, 255, 0.2)",
-			fidgetBorderRadius: "12px",
-			gridSpacing: "16",
-		},
-	};
-
-	config.fidgetInstanceDatums = {
-		profile: {
-			id: "profile",
-			fidgetType: "profile",
-			config: {
-				data: { fid },
-				editable: true,
-				settings: {
-					showAvatar: true,
-					showUsername: true,
-					showStats: true,
-				},
-			},
-		},
-		portfolio: {
-			id: "portfolio",
-			fidgetType: "Portfolio",
-			config: {
-				data: {},
-				editable: true,
-				settings: {
-					showBalance: true,
-					showValue: true,
-					showChange: true,
-				},
-			},
-		},
-		feed: {
-			id: "feed",
-			fidgetType: "feed",
-			config: {
-				data: {},
-				editable: true,
-				settings: {
-					showUserCasts: true,
-					showTokenDiscussions: true,
-					maxCasts: 20,
-				},
-			},
-		},
-		"market-data": {
-			id: "market-data",
-			fidgetType: "Market",
-			config: {
-				data: {},
-				editable: true,
-				settings: {
-					showUserTokens: true,
-					showPriceChanges: true,
-				},
-			},
-		},
-		gallery: {
-			id: "gallery",
-			fidgetType: "gallery",
-			config: {
-				data: {},
-				editable: true,
-				settings: {
-					showUserImages: true,
-					showTokenImages: true,
-					maxImages: 15,
-				},
-			},
-		},
-		links: {
-			id: "links",
-			fidgetType: "links",
-			config: {
-				data: {},
-				editable: true,
-				settings: {
-					showUserLinks: true,
-					showTokenLinks: true,
-				},
-			},
-		},
-	};
-
-	const layoutItems = [
-		{ w: 6, h: 4, x: 0, y: 0, i: "profile" },
-		{ w: 6, h: 4, x: 6, y: 0, i: "portfolio" },
-		{ w: 8, h: 4, x: 0, y: 4, i: "feed" },
-		{ w: 4, h: 4, x: 8, y: 4, i: "market-data" },
-		{ w: 6, h: 3, x: 0, y: 8, i: "gallery" },
-		{ w: 6, h: 3, x: 6, y: 8, i: "links" },
-	];
-
-	const layoutConfig = getLayoutConfig(config.layoutDetails);
-	layoutConfig.layout = layoutItems;
-
-	config.tabNames = ["Profile"];
-
-	return config;
+  // Set the layout configuration
+  const layoutConfig = getLayoutConfig(config.layoutDetails);
+  layoutConfig.layout = layoutItems;
+  
+  // Set default tab names
+  config.tabNames = ["Profile"];
+  
+  return config;
 };
 
 export default createInitialProfileSpaceConfigForFid;

--- a/src/config/clanker/initialSpaces/initialProposalSpace.ts
+++ b/src/config/clanker/initialSpaces/initialProposalSpace.ts
@@ -1,113 +1,219 @@
 import { SpaceConfig } from "@/app/(spaces)/Space";
 import { cloneDeep } from "lodash";
-import { getLayoutConfig } from "@/common/utils/layoutFormatUtils";
 import { INITIAL_SPACE_CONFIG_EMPTY } from "../../initialSpaceConfig";
+import { Address } from "viem";
 
-const createInitialProposalSpaceConfigForProposalId = (
-	proposalId: string,
+export const createInitalProposalSpaceConfigForProposalId = (
+  proposalId: string,
+  proposerAddress: Address
 ): Omit<SpaceConfig, "isEditable"> => {
-	const config = cloneDeep(INITIAL_SPACE_CONFIG_EMPTY);
+  const config = cloneDeep(INITIAL_SPACE_CONFIG_EMPTY);
 
-	config.theme = {
-		id: "clanker-proposal-theme",
-		name: "Clanker Proposal Theme",
-		properties: {
-			font: "Inter, system-ui, sans-serif",
-			fontColor: "#ffffff",
-			headingsFont: "Inter, system-ui, sans-serif",
-			headingsFontColor: "#ff6b6b",
-			background:
-				"linear-gradient(135deg, #ff6b6b 0%, #4ecdc4 50%, #45b7d1 100%)",
-			backgroundHTML: "",
-			musicURL: "",
-			fidgetBackground: "#ff6b6b",
-			fidgetBorderWidth: "2px",
-			fidgetBorderColor: "#ff6b6b",
-			fidgetShadow: "0 6px 24px rgba(255, 107, 107, 0.3)",
-			fidgetBorderRadius: "16px",
-			gridSpacing: "20",
-		},
-	};
+  config.fidgetInstanceDatums = {
+    "iframe:2f0a1c7b-da0c-474c-ad30-59915d0096b1": {
+      config: {
+        editable: true,
+        data: {},
+        settings: {
+          url: `https://www.nouns.camp/proposals/${proposalId}?tab=description`,
+          showOnMobile: true,
+          customMobileDisplayName: "Proposal",
+          background: "var(--user-theme-fidget-background)",
+          fidgetBorderWidth: "var(--user-theme-fidget-border-width)",
+          fidgetBorderColor: "var(--user-theme-fidget-border-color)",
+          fidgetShadow: "var(--user-theme-fidget-shadow)",
+        },
+      },
+      fidgetType: "iframe",
+      id: "iframe:2f0a1c7b-da0c-474c-ad30-59915d0096b1",
+    },
+    "iframe:10e88b10-b999-4ddc-a577-bd0eeb6bc76d": {
+      config: {
+        editable: true,
+        data: {},
+        settings: {
+          url: "https://euphonious-kulfi-5e5a30.netlify.app/?id=" + proposalId,
+          showOnMobile: true,
+          customMobileDisplayName: "TLDR",
+          background: "var(--user-theme-fidget-background)",
+          fidgetBorderWidth: "var(--user-theme-fidget-border-width)",
+          fidgetBorderColor: "var(--user-theme-fidget-border-color)",
+          fidgetShadow: "var(--user-theme-fidget-shadow)",
+        },
+      },
+      fidgetType: "iframe",
+      id: "iframe:10e88b10-b999-4ddc-a577-bd0eeb6bc76d",
+    },
+    "iframe:1afc071b-ce6b-4527-9419-f2e057a9fb0a": {
+      config: {
+        editable: true,
+        data: {},
+        settings: {
+          url: `https://www.nouns.camp/proposals/${proposalId}?tab=activity`,
+          showOnMobile: true,
+          customMobileDisplayName: "Activity",
+          background: "var(--user-theme-fidget-background)",
+          fidgetBorderWidth: "var(--user-theme-fidget-border-width)",
+          fidgetBorderColor: "var(--user-theme-fidget-border-color)",
+          fidgetShadow: "var(--user-theme-fidget-shadow)",
+        },
+      },
+      fidgetType: "iframe",
+      id: "iframe:1afc071b-ce6b-4527-9419-f2e057a9fb0a",
+    },
+    "iframe:ffb3cd56-3203-4b94-b842-adab9a7eabc9": {
+      config: {
+        editable: true,
+        data: {},
+        settings: {
+          url: `https://chat-fidget.vercel.app/?room=prop%20${proposalId}%20chat&owner=${proposerAddress}`,
+          showOnMobile: true,
+          customMobileDisplayName: "Chat",
+          background: "var(--user-theme-fidget-background)",
+          fidgetBorderWidth: "var(--user-theme-fidget-border-width)",
+          fidgetBorderColor: "var(--user-theme-fidget-border-color)",
+          fidgetShadow: "var(--user-theme-fidget-shadow)",
+        },
+      },
+      fidgetType: "iframe",
+      id: "iframe:ffb3cd56-3203-4b94-b842-adab9a7eabc9",
+    },
+  };
 
-	config.fidgetInstanceDatums = {
-		text: {
-			id: "text",
-			fidgetType: "text",
-			config: {
-				data: { proposalId },
-				editable: true,
-				settings: {
-					showProposalText: true,
-					showTitle: true,
-					showDescription: true,
-				},
-			},
-		},
-		SnapShot: {
-			id: "SnapShot",
-			fidgetType: "SnapShot",
-			config: {
-				data: { proposalId },
-				editable: true,
-				settings: {
-					showVoting: true,
-					showResults: true,
-					showVoteCount: true,
-				},
-			},
-		},
-		feed: {
-			id: "feed",
-			fidgetType: "feed",
-			config: {
-				data: { proposalId },
-				editable: true,
-				settings: {
-					showProposalDiscussions: true,
-					maxCasts: 15,
-				},
-			},
-		},
-		links: {
-			id: "links",
-			fidgetType: "links",
-			config: {
-				data: { proposalId },
-				editable: true,
-				settings: {
-					showProposalLinks: true,
-					showExternalVoting: true,
-				},
-			},
-		},
-		gallery: {
-			id: "gallery",
-			fidgetType: "gallery",
-			config: {
-				data: { proposalId },
-				editable: true,
-				settings: {
-					showProposalImages: true,
-					maxImages: 8,
-				},
-			},
-		},
-	};
+  config.layoutDetails = {
+    layoutConfig: {
+      layout: [
+        {
+          w: 4,
+          h: 10,
+          x: 0,
+          y: 0,
+          i: "iframe:2f0a1c7b-da0c-474c-ad30-59915d0096b1",
+          minW: 2,
+          maxW: 36,
+          minH: 2,
+          maxH: 36,
+          moved: false,
+          static: false,
+          resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+          isBounded: false,
+        },
+        {
+          w: 4,
+          h: 6,
+          x: 4,
+          y: 0,
+          i: "iframe:10e88b10-b999-4ddc-a577-bd0eeb6bc76d",
+          minW: 2,
+          maxW: 36,
+          minH: 2,
+          maxH: 36,
+          moved: false,
+          static: false,
+          resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+        },
+        {
+          w: 4,
+          h: 10,
+          x: 8,
+          y: 0,
+          i: "iframe:1afc071b-ce6b-4527-9419-f2e057a9fb0a",
+          minW: 2,
+          maxW: 36,
+          minH: 2,
+          maxH: 36,
+          moved: false,
+          static: false,
+          resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+          isBounded: false,
+        },
+        {
+          w: 4,
+          h: 4,
+          x: 4,
+          y: 6,
+          i: "iframe:ffb3cd56-3203-4b94-b842-adab9a7eabc9",
+          minW: 2,
+          maxW: 36,
+          minH: 2,
+          maxH: 36,
+          moved: false,
+          static: false,
+          resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+          isBounded: false,
+        },
+      ],
+    },
+    layoutFidget: "default-layout-fidget", // Assign a valid string value
+  };
 
-	const layoutItems = [
-		{ w: 8, h: 4, x: 0, y: 0, i: "text" },
-		{ w: 4, h: 4, x: 8, y: 0, i: "SnapShot" },
-		{ w: 6, h: 4, x: 0, y: 4, i: "feed" },
-		{ w: 6, h: 4, x: 6, y: 4, i: "links" },
-		{ w: 12, h: 3, x: 0, y: 8, i: "gallery" },
-	];
+  config.theme = {
+    id: "Homebase-Tab 10-Theme",
+    name: "Homebase-Tab 10-Theme",
+    properties: {
+      background: "#ffffff",
+      backgroundHTML: `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Nouns DAO Animated Background</title>
+  <style>
+    html,body{height:100%;margin:0;overflow:hidden;}
+    body{
+      position:relative;
+      background:linear-gradient(160deg,#FCCD04 0%,#E80173 20%,#45AAF2 40%,#23D160 60%,#FDB900 80%,#C8A2C8 100%);
+      background-size:400% 400%;
+      animation:gradientFlow 30s ease-in-out infinite;
+    }
+    body::before,
+    body::after{
+      content:"";
+      position:absolute;
+      left:0;
+      right:0;
+      bottom:-15%;
+      height:200%;
+      background-image:url("https://nouns.wtf/brand-assets/color_noggles.png");
+      background-repeat:repeat-x;
+      background-size:60px 60px;
+      opacity:0.6;
+      animation:floatUp 20s linear infinite;
+    }
+    body::after{
+      bottom:-30%;
+      background-size:40px 40px;
+      opacity:0.4;
+      animation-duration:25s;
+      animation-direction:reverse;
+    }
+    @keyframes gradientFlow{
+      0%{background-position:0% 50%;}
+      50%{background-position:100% 50%;}
+      100%{background-position:0% 50%;}
+    }
+    @keyframes floatUp{
+      from{transform:translateY(0);}
+      to{transform:translateY(-50%);}
+    }
+  </style>
+</head>
+<body></body>
+</html>`,
+      fidgetBackground: "#ffffff",
+      fidgetBorderColor: "#eeeeee",
+      fidgetBorderWidth: "1px",
+      fidgetShadow: "none",
+      font: "Inter",
+      fontColor: "#000000",
+      headingsFont: "Londrina Solid",
+      headingsFontColor: "#000000",
+      musicURL: "https://www.youtube.com/watch?v=dMXlZ4y7OK4&t=1804",
+      fidgetBorderRadius: "12px",
+      gridSpacing: "16",
+    },
+  };
 
-	const layoutConfig = getLayoutConfig(config.layoutDetails);
-	layoutConfig.layout = layoutItems;
-
-	config.tabNames = ["Proposal"];
-
-	return config;
+  return config;
 };
 
-export default createInitialProposalSpaceConfigForProposalId;
+export default createInitalProposalSpaceConfigForProposalId;

--- a/src/config/clanker/initialSpaces/initialTokenSpace.ts
+++ b/src/config/clanker/initialSpaces/initialTokenSpace.ts
@@ -1,151 +1,445 @@
 import { SpaceConfig } from "@/app/(spaces)/Space";
 import { cloneDeep } from "lodash";
-import { getLayoutConfig } from "@/common/utils/layoutFormatUtils";
 import { INITIAL_SPACE_CONFIG_EMPTY } from "../../initialSpaceConfig";
+import { getNetworkWithId } from "@/common/lib/utils/networks";
+import { EtherScanChainName } from "../../../constants/etherscanChainIds";
+import { getGeckoUrl } from "@/common/lib/utils/links";
+import { Address } from "viem";
+import { getLayoutConfig } from "@/common/utils/layoutFormatUtils";
 
-const createInitialTokenSpaceConfigForAddress = (
-	tokenAddress: string,
+export const createInitialTokenSpaceConfigForAddress = (
+  address: string,
+  castHash: string | null,
+  casterFid: string | null,
+  symbol: string,
+  isClankerToken: boolean,
+  network: EtherScanChainName = "base",
 ): Omit<SpaceConfig, "isEditable"> => {
-	const config = cloneDeep(INITIAL_SPACE_CONFIG_EMPTY);
+  const config = cloneDeep(INITIAL_SPACE_CONFIG_EMPTY);
 
-	config.theme = {
-		id: "clanker-token-theme",
-		name: "Clanker Token Theme",
-		properties: {
-			font: "Inter, system-ui, sans-serif",
-			fontColor: "#ffffff",
-			headingsFont: "Inter, system-ui, sans-serif",
-			headingsFontColor: "#ffd700",
-			background: "linear-gradient(135deg, #2d1b69 0%, #11998e 100%)",
-			backgroundHTML: "",
-			musicURL: "",
-			fidgetBackground: "#ffd700",
-			fidgetBorderWidth: "2px",
-			fidgetBorderColor: "#ffd700",
-			fidgetShadow: "0 4px 20px rgba(255, 215, 0, 0.2)",
-			fidgetBorderRadius: "12px",
-			gridSpacing: "16",
-		},
-	};
+  config.fidgetInstanceDatums = {
+    "Swap:f9e0259a-4524-4b37-a261-9f3be26d4af1": {
+      config: {
+        data: {},
+        editable: true,
+        settings: {
+          defaultBuyToken: address,
+          defaultSellToken: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          fromChain: getNetworkWithId(network),
+          toChain: getNetworkWithId(network),
+          size: 0.8,
+        },
+      },
+      fidgetType: "Swap",
+      id: "Swap:f9e0259a-4524-4b37-a261-9f3be26d4af1",
+    },
+    ...(isClankerToken &&
+      castHash &&
+      casterFid &&
+      castHash !== "clank.fun deployment" && {
+        "cast:9c63b80e-bd46-4c8e-9e4e-c6facc41bf71": {
+          config: {
+            data: {},
+            editable: true,
+            settings: {
+              background: "var(--user-theme-fidget-background)",
+              castHash: castHash,
+              casterFid: casterFid,
+              fidgetBorderColor: "var(--user-theme-fidget-border-color)",
+              fidgetBorderWidth: "var(--user-theme-fidget-border-width)",
+              fidgetShadow: "var(--user-theme-fidget-shadow)",
+            },
+          },
+          fidgetType: "cast",
+          id: "cast:9c63b80e-bd46-4c8e-9e4e-c6facc41bf71",
+        },
+      }),
+    "feed:3de67742-56f2-402c-b751-7e769cdcfc56": {
+      config: {
+        data: {},
+        editable: true,
+        settings: {
+          Xhandle: "thenounspace",
+          background: "var(--user-theme-fidget-background)",
+          feedType: "filter",
+          keyword: `$${symbol}`,
+          fidgetBorderColor: "var(--user-theme-fidget-border-color)",
+          fidgetBorderWidth: "var(--user-theme-fidget-border-width)",
+          fidgetShadow: "var(--user-theme-fidget-shadow)",
+          filterType: "keyword",
+          fontColor: "var(--user-theme-font-color)",
+          fontFamily: "var(--user-theme-font)",
+        },
+      },
+      fidgetType: "feed",
+      id: "feed:3de67742-56f2-402c-b751-7e769cdcfc56",
+    },
+    "Market:733222fa-38f8-4343-9fa2-6646bb47dde0": {
+      config: {
+        data: {},
+        editable: true,
+        settings: {
+          background: "var(--user-theme-fidget-background)",
+          fidgetBorderColor: "var(--user-theme-fidget-border-color)",
+          fidgetBorderWidth: "var(--user-theme-fidget-border-width)",
+          fidgetShadow: "var(--user-theme-fidget-shadow)",
+          chain: getNetworkWithId(network),
+          token: address,
+          dataSource: "geckoterminal",
+          theme: "light",
+          size: 1,
+        },
+      },
 
-	config.fidgetInstanceDatums = {
-		"market-data": {
-			id: "market-data",
-			fidgetType: "Market",
-			config: {
-				data: { tokenAddress },
-				editable: true,
-				settings: {
-					showTokenData: true,
-					showPrice: true,
-					showMarketCap: true,
-				},
-			},
-		},
-		portfolio: {
-			id: "portfolio",
-			fidgetType: "Portfolio",
-			config: {
-				data: { tokenAddress },
-				editable: true,
-				settings: {
-					showTokenHoldings: true,
-					showValue: true,
-					showChange: true,
-				},
-			},
-		},
-		swap: {
-			id: "swap",
-			fidgetType: "Swap",
-			config: {
-				data: { tokenAddress },
-				editable: true,
-				settings: {
-					showTokenSwap: true,
-					showAmountInput: true,
-				},
-			},
-		},
-		feed: {
-			id: "feed",
-			fidgetType: "feed",
-			config: {
-				data: { tokenAddress },
-				editable: true,
-				settings: {
-					showTokenDiscussions: true,
-					maxCasts: 15,
-				},
-			},
-		},
-		gallery: {
-			id: "gallery",
-			fidgetType: "gallery",
-			config: {
-				data: { tokenAddress },
-				editable: true,
-				settings: {
-					showTokenImages: true,
-					maxImages: 12,
-				},
-			},
-		},
-		links: {
-			id: "links",
-			fidgetType: "links",
-			config: {
-				data: { tokenAddress },
-				editable: true,
-				settings: {
-					showTokenLinks: true,
-					showExternalTools: true,
-				},
-			},
-		},
-		text: {
-			id: "text",
-			fidgetType: "text",
-			config: {
-				data: { tokenAddress },
-				editable: true,
-				settings: {
-					showTokenDescription: true,
-					showContractInfo: true,
-				},
-			},
-		},
-		iframe: {
-			id: "iframe",
-			fidgetType: "iframe",
-			config: {
-				data: { tokenAddress },
-				editable: true,
-				settings: {
-					showTokenAnalytics: true,
-					url: `https://analytics.clanker.world/token/${tokenAddress}`,
-				},
-			},
-		},
-	};
+      fidgetType: "Market",
+      id: "Market:733222fa-38f8-4343-9fa2-6646bb47dde0",
+    },
+    "links:5b4c8b73-416d-4842-9dc5-12fc186d8f57": {
+      config: {
+        data: {},
+        editable: true,
+        settings: {
+          DescriptionColor: "black",
+          HeaderColor: "black",
+          background: "rgba(255, 255, 255, 0.5)",
+          css: "",
+          fidgetBorderColor: "var(--user-theme-fidget-border-color)",
+          fidgetBorderWidth: "var(--user-theme-fidget-border-width)",
+          fidgetShadow: "var(--user-theme-fidget-shadow)",
+          headingsFontFamily: "'__Inter_d65c78', '__Inter_Fallback_d65c78'",
+          itemBackground: "#e0eeff",
+          links: [
+            ...(isClankerToken
+              ? [
+                  {
+                    avatar:
+                      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAMAAABF0y+mAAAAM1BMVEX////q5PfUxe7o4fbMu+uPadTGs+jKueqJYNHEseiJYtKOZ9PJt+rUx+7MuuvPwOvm3vVnLuiEAAAAXUlEQVR4Ac3QAxaAQAAE0LXR/S+bXdNDWuOvSSGBMsYhCikVRG2MxejcFZoHcXoDQCF9gBiMURC1cfYzpDFSiEnKAHF6w4TuiMscs0bt+69JQyW8VyvkOVeH6p/QAF54BSckEkJ8AAAAAElFTkSuQmCC",
+                    description: "",
+                    text: "Clanker.world",
+                    url: `https://www.clanker.world/clanker/${address}`,
+                  },
+                ]
+              : []),
+            {
+              avatar:
+                "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBwgHBgkIBwgKCgkLDRYPDQwMDRsUFRAWIB0iIiAdHx8kKDQsJCYxJx8fLT0tMTU3Ojo6Iys/RD84QzQ5OjcBCgoKDQwNGg8PGjclHyU3Nzc3Nzc3Ljc3Nzc3Nzg3Nzc3NzctKzc3Nzc3Nzc3Kzc3Nzc3Nzc3ODc3Nzc3Nys3N//AABEIABwAHAMBIgACEQEDEQH/xAAaAAABBQEAAAAAAAAAAAAAAAAHAgQFBggD/8QAKRAAAgEDAgQFBQAAAAAAAAAAAQIDAAURBDEGEiFREyJBccEHFKHR8P/EABgBAAIDAAAAAAAAAAAAAAAAAAIDAQQF/8QAHhEAAQQDAAMAAAAAAAAAAAAAAgABAxEEEiETQVH/2gAMAwEAAhEDEQA/ABZGperdZOBdRcYQ87SpI4ykMcfM2O5HxTbgPQQ6ozayXDNAwCIdgd8n4o4/TZJ5LNNrdVpmgaedhEHGHMa4AJ925j7YrekIYofI7WnuVMs/3zhi4WdpDPEJIY3MbTRMHVG6eV8E8jdR5WwagmBBxR6v3FMV5F5suj0/2ulaR4JplQBpzjDMD+O+3WgHqX8Od05geViMjY0stmBiNqtRfOrvYb3PaNWJYTlT0dDs47H9+lGvhLjKRLa7W9hNC4OI5D1gf+9NjvWeSxpxBrJ4VYRyFQRg4O4qvDliw6SNYoNr46vfGHE6xNJpdFJmRifFlXv6gfJoftJzMSaS7s5yxyaTScnLKcr9Ib+L/9k=",
+              description: "",
+              text: "GeckoTerminal",
+              url: getGeckoUrl(address as Address, network),
+            },
+            {
+              avatar:
+                "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAEGElEQVR4AbWWA5AcXRSFX2ytbe/+DNccx6vYtm3bTjm2jUGyVg/CRmzb6dwXdO12LaYHt+oMu/s797zbQMYWy7JVMzIyYkaPHjstOTlln1SmKBCJpDfFYukNqUxe2D459cCwESOmnz17Nh62rY4sVXfu3LGZOHHiJIlUdsfG1v577Tr12PLUyMaOFUuk9ydPnjqNJEl7k8HQRZWVK1f2a9Y8/GmduvU5gLHC+zRr3uL50uXLB+P0BMFfvnzZqHvPXkegY8Fgvho2smW79ehx8vXr17bGRu4qkyl05oL5kkikV+7fv+9RYecyOQe3uKRyBTZhV+aa9+7d95CloXx179HrRKkzsWLF6t4wwd/NBSQmibW7d+9OP3DgSFuscRMmbIY5KDETK1asGFQCjgckPDzysSU63LNnT2f+9SMqKuZ98W2aNw9//ubNGwduo6lTp46rW6+BRSI+efJkMuJVTEzca/4pOmHSpKnc2sNwMEIgdvaObOs2bTPaJaccxFK0bFXQoKGN0QawRCLJPWBXQ3B5Dbe1cxC09smpaSdh50rFYq4sb9kqV4gB3ARUMBo9evQkoTF36dJ1Ix+SnJy6V4iB6OjYV2CgAUpLS99dTtTf/fwDPvv5B3729PT+CmtnEQNOzq7fVq9e3QnhgqteXmlwX1//L0eOHGkFLp2x4CLlDXfBU+YawMs9d+78idyfIrGk1AFMSEy6iXi1YMGigeYYcHRy+Y6n/8/8qAiyK0qCe3qpBhJENxCvli1b1s9UAz4+fp8XLFo0/A9cSVxvqSq6rkVSqVxnbQPDho2gt27dKvvzPeMyFaYirj9TEuRF1LZd8hFrG4Cunf58Vhbd8FIR1E2InwUTO9CAQYPmW9kAVxcIOgDAzC84SEtORAcOH5bBZdgiBmDC2UKtNrE0uJKgoyDyhxwcS8tE43jqRsfEPjfXwPLly6fjO2op8VeCqIcC/GNxOHy/m5+fXw3hGjhw8HIhBrp3774GGVFKLekGsMMYyJdaS07nNtTr9b4BgcEfStzXE0UM4tWuXbu6QNRnzp8/H1oe2GBgq8P6DgTQ89Lg0P3Ls3rGkXeRWTA8MCjko5u757d//v3//dix45aUFmd54N1wZwVwK1UReYkH5WtUWY9ljiAvUH0koHYbDNXVBNlLWXSdqAAM3V+/cPw4WQOZWziN8zqqsVpLLeFNdzmibmYS11xNhp7SauvAQeJVWnoexHzZOCh3zt/O0FJhRsM2wimiKSRDNFo6WU1Qs2FqVXCgN4KgHJzKO1fIeCIhhc9RiHYCOH8rHMrpA+w/L/POnVrI1FLnUu5woGWg1wLA7yC1DcpLlB+yVGWTZH2NlkmBjtbCwTNg6h/BHHwF2FeY/qdwtcuB/zapdXSnzEt3bJCR9QPwKOxl9MLyXAAAAABJRU5ErkJggg==",
+              description: "",
+              text: "BaseScan",
+              url: `https://basescan.org/address/${address}`,
+            },
+          ],
+          title: `$${symbol} Links`,
+          viewMode: "list",
+        },
+      },
+      fidgetType: "links",
+      id: "links:5b4c8b73-416d-4842-9dc5-12fc186d8f57",
+    },
+    "Chat:09528872-6659-460e-bb25-0c200cccb0ec": {
+      config: {
+        data: {},
+        editable: true,
+        settings: {
+          background: "var(--user-theme-fidget-background)",
+          fidgetBorderColor: "var(--user-theme-fidget-border-color)",
+          fidgetBorderWidth: "var(--user-theme-fidget-border-width)",
+          fidgetShadow: "var(--user-theme-fidget-shadow)",
+          roomName: address,
+        },
+      },
+      fidgetType: "Chat",
+      id: "Chat:09528872-6659-460e-bb25-0c200cccb0ec",
+    },
+  };
 
-	const layoutItems = [
-		{ w: 6, h: 4, x: 0, y: 0, i: "market-data" },
-		{ w: 6, h: 4, x: 6, y: 0, i: "portfolio" },
-		{ w: 4, h: 3, x: 0, y: 4, i: "swap" },
-		{ w: 4, h: 3, x: 4, y: 4, i: "feed" },
-		{ w: 4, h: 3, x: 8, y: 4, i: "gallery" },
-		{ w: 8, h: 4, x: 0, y: 7, i: "links" },
-		{ w: 4, h: 4, x: 8, y: 7, i: "text" },
-		{ w: 12, h: 3, x: 0, y: 11, i: "iframe" },
-	];
+  const newLayout = isClankerToken &&
+    castHash &&
+    casterFid &&
+    castHash !== "clank.fun deployment"
+      ? [
+          {
+            h: 6,
+            i: "Chat:09528872-6659-460e-bb25-0c200cccb0ec",
+            maxH: 36,
+            maxW: 36,
+            minH: 2,
+            minW: 2,
+            moved: false,
+            resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+            static: false,
+            w: 4,
+            x: 4,
+            y: 4,
+          },
+          {
+            h: 8,
+            i: "feed:3de67742-56f2-402c-b751-7e769cdcfc56",
+            maxH: 36,
+            maxW: 36,
+            minH: 2,
+            minW: 4,
+            moved: false,
+            resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+            static: false,
+            w: 4,
+            x: 8,
+            y: 0,
+          },
+          {
+            h: 5,
+            i: "Swap:f9e0259a-4524-4b37-a261-9f3be26d4af1",
+            maxH: 36,
+            maxW: 36,
+            minH: 3,
+            minW: 2,
+            moved: false,
+            resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+            static: false,
+            w: 4,
+            x: 0,
+            y: 5,
+          },
+          {
+            h: 5,
+            i: "Market:733222fa-38f8-4343-9fa2-6646bb47dde0",
+            maxH: 36,
+            maxW: 36,
+            minH: 2,
+            minW: 2,
+            moved: false,
+            resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+            static: false,
+            w: 4,
+            x: 0,
+            y: 0,
+          },
+          {
+            h: 2,
+            i: "links:5b4c8b73-416d-4842-9dc5-12fc186d8f57",
+            maxH: 36,
+            maxW: 36,
+            minH: 2,
+            minW: 2,
+            moved: false,
+            resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+            static: false,
+            w: 4,
+            x: 8,
+            y: 8,
+          },
+          {
+            h: 4,
+            i: "cast:9c63b80e-bd46-4c8e-9e4e-c6facc41bf71",
+            maxH: 4,
+            maxW: 12,
+            minH: 1,
+            minW: 3,
+            moved: false,
+            resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+            static: false,
+            w: 4,
+            x: 4,
+            y: 0,
+          },
+        ]
+      : [
+          {
+            h: 8,
+            i: "Chat:09528872-6659-460e-bb25-0c200cccb0ec",
+            maxH: 36,
+            maxW: 36,
+            minH: 2,
+            minW: 2,
+            moved: false,
+            resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+            static: false,
+            w: 4,
+            x: 4,
+            y: 0,
+          },
+          {
+            h: 2,
+            i: "links:5b4c8b73-416d-4842-9dc5-12fc186d8f57",
+            maxH: 36,
+            maxW: 36,
+            minH: 2,
+            minW: 2,
+            moved: false,
+            resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+            static: false,
+            w: 4,
+            x: 4,
+            y: 8,
+          },
+          {
+            h: 10,
+            i: "feed:3de67742-56f2-402c-b751-7e769cdcfc56",
+            maxH: 36,
+            maxW: 36,
+            minH: 2,
+            minW: 4,
+            moved: false,
+            resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+            static: false,
+            w: 4,
+            x: 8,
+            y: 0,
+          },
+          {
+            h: 5,
+            i: "Market:733222fa-38f8-4343-9fa2-6646bb47dde0",
+            maxH: 36,
+            maxW: 36,
+            minH: 2,
+            minW: 2,
+            moved: false,
+            resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+            static: false,
+            w: 4,
+            x: 0,
+            y: 0,
+          },
+          {
+            h: 5,
+            i: "Swap:f9e0259a-4524-4b37-a261-9f3be26d4af1",
+            maxH: 36,
+            maxW: 36,
+            minH: 3,
+            minW: 2,
+            moved: false,
+            resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+            static: false,
+            w: 4,
+            x: 0,
+            y: 5,
+          },
+        ];
 
-	const layoutConfig = getLayoutConfig(config.layoutDetails);
-	layoutConfig.layout = layoutItems;
+  // Set the layout configuration
+  const layoutConfig = getLayoutConfig(config.layoutDetails);
+  layoutConfig.layout = newLayout;
 
-	config.tabNames = ["Token"];
+  config.theme = {
+    id: "default",
+    name: "Default",
+    properties: {
+      background: "#ffffff",
+      backgroundHTML: `
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+          <meta charset="UTF-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+          <title>Aurora Borealis (Light Theme)</title>
+          <style>
+            /* 1. Page Reset & Lighter Background */
+            body {
+              margin: 0;
+              height: 100vh;
+              /* A subtle sky-like gradient */
+              background: linear-gradient(180deg, #eef9ff, #dbeffd);
+              overflow: hidden;
+              display: flex;
+              justify-content: center;
+              align-items: center;
+              font-family: Arial, sans-serif;
+              color: #333; /* darker text for contrast */
+              position: relative;
+            }
 
-	return config;
+            /* 2. Aurora Gradient (Pastel & Blurred) */
+            .aurora {
+              position: absolute;
+              top: 0;
+              left: 0;
+              width: 100%;
+              height: 100%;
+              background: linear-gradient(
+                120deg,
+                rgba(102, 178, 255, 0.4),
+                rgba(102, 255, 178, 0.4),
+                rgba(255, 153, 255, 0.4),
+                rgba(153, 204, 255, 0.4)
+              );
+              background-size: 200% 200%;
+              animation: aurora 10s infinite ease-in-out;
+              /* A gentle blur to enhance the glow effect */
+              filter: blur(40px);
+            }
+
+            @keyframes aurora {
+              0% {
+                background-position: 0% 50%;
+              }
+              50% {
+                background-position: 100% 50%;
+              }
+              100% {
+                background-position: 0% 50%;
+              }
+            }
+
+            /* 3. Optional Content Layer (above the aurora) */
+            .content {
+              /* z-index: 1; */
+              text-align: center;
+              position: relative;
+            }
+
+            .content h1 {
+              font-size: 3rem;
+              margin: 0;
+              color: #006070; /* teal-ish for a calmer look */
+            }
+
+            .content p {
+              font-size: 1.5rem;
+              margin: 10px 0 0;
+              color: #009688;
+            }
+
+            /* 4. Light, Subtle Overlay */
+            /* Using white in the radial gradient for a more diffused look */
+            .overlay {
+              position: absolute;
+              top: 0;
+              left: 0;
+              width: 100%;
+              height: 100%;
+              background: radial-gradient(circle, rgba(255, 255, 255, 0) 35%, rgba(255, 255, 255, 0.3) 100%);
+              pointer-events: none;
+              /* z-index: 0;*/
+            }
+          </style>
+        </head>
+        <body>
+          <div class="aurora"></div>
+          <div class="overlay"></div>
+        </body>
+        </html>
+      `,
+      fidgetBackground: "#ffffffb0", // equivalent to rgba(255, 255, 255, 0.69)
+      fidgetBorderColor: "#eeeeee", // equivalent to rgba(238, 238, 238, 1)
+      fidgetBorderWidth: "0",
+      fidgetShadow: "none",
+      font: "Inter",
+      fontColor: "#000000",
+      headingsFont: "Inter",
+      headingsFontColor: "#000000",
+      musicURL: "https://www.youtube.com/watch?v=dMXlZ4y7OK4&t=1804",
+      fidgetBorderRadius: "12px",
+      gridSpacing: "16",
+    },
+  };
+
+  return config;
 };
 
 export default createInitialTokenSpaceConfigForAddress;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -86,7 +86,7 @@ function resolveCommunity(): CommunityConfig {
 export const createInitialProfileSpaceConfigForFid = (fid: number, username?: string) => {
   switch (resolveCommunity()) {
     case 'clanker':
-      return clankerCreateInitialProfileSpaceConfigForFid(fid);
+      return clankerCreateInitialProfileSpaceConfigForFid(fid, username);
     case 'example':
       return exampleCreateInitialProfileSpaceConfigForFid(fid, username);
     case 'nouns':

--- a/src/config/systemConfig.ts
+++ b/src/config/systemConfig.ts
@@ -136,7 +136,7 @@ export interface NavigationItem {
   id: string;
   label: string;
   href: string;
-  icon?: 'home' | 'explore' | 'notifications' | 'search' | 'space' | 'custom';
+  icon?: 'home' | 'explore' | 'notifications' | 'search' | 'space' | 'robot' | 'custom';
   openInNewTab?: boolean;
   requiresAuth?: boolean;
 }

--- a/tests/clankerInitialSpaces.test.ts
+++ b/tests/clankerInitialSpaces.test.ts
@@ -1,0 +1,28 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createInitialProfileSpaceConfigForFid } from "@/config";
+
+const PORTFOLIO_FIDGET_ID = "Portfolio:cd627e89-d661-4255-8c4c-2242a950e93e";
+
+describe("clanker initial profile space config", () => {
+  const originalCommunity = process.env.NEXT_PUBLIC_COMMUNITY;
+
+  beforeAll(() => {
+    process.env.NEXT_PUBLIC_COMMUNITY = "clanker";
+  });
+
+  afterAll(() => {
+    process.env.NEXT_PUBLIC_COMMUNITY = originalCommunity;
+  });
+
+  it("passes the farcaster username to the Portfolio fidget settings", () => {
+    const username = "clankerfan";
+
+    const config = createInitialProfileSpaceConfigForFid(123, username);
+    const portfolioFidget = config.fidgetInstanceDatums?.[PORTFOLIO_FIDGET_ID];
+
+    expect(portfolioFidget).toBeDefined();
+    expect(
+      portfolioFidget?.config?.settings?.farcasterUsername,
+    ).toBe(username);
+  });
+});


### PR DESCRIPTION
## Summary
- replace the placeholder trading-focused tabs with the provided Clank, Social, and Docs configurations
- set the tab order and default tab to match the desired Clanker space experience

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_690d077ec35483259c9dba71738f577d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Robot icon added; new $CLANKER navigation item
  * New "Clank", "Social", and "Docs" tabs

* **UI/UX Changes**
  * Homepage default tab set to "Clank" with a single embedded view replacing the multi-widget dashboard
  * Lighter/white default theme; new onboarding content for homebase and profile
  * Proposal, token, and docs pages now use streamlined embedded views

* **Chores**
  * Site icon/favicon switched to SVG

* **Tests**
  * Added unit test covering profile username propagation into profile setup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->