### PR TITLE
feat: make brand tooltip configurable

### DIFF
--- a/src/common/components/molecules/BrandHeader.tsx
+++ b/src/common/components/molecules/BrandHeader.tsx
@@ -14,45 +14,66 @@ import { loadSystemConfig } from "@/config";
 const Londrina = Londrina_Solid({ subsets: ["latin"], weight: "400" });
 
 const BrandHeader = () => {
-  const { assets, brand } = loadSystemConfig();
+  const { assets, brand, navigation } = loadSystemConfig();
+  const logoTooltip = navigation?.logoTooltip;
   const logoSrc = assets.logos.icon || assets.logos.main;
+
+  const logoImage = (
+    <div className="w-12 h-8 sm:w-16 sm:h-10 me-3 flex items-center justify-center">
+      <Image
+        src={logoSrc}
+        alt={`${brand.displayName} Logo`}
+        width={60}
+        height={40}
+        priority
+        className="w-full h-full object-contain"
+      />
+    </div>
+  );
+
   return (
     <>
-      <TooltipProvider>
-        <Tooltip>
-          <Link
-            href="/home"
-            className="flex items-center ps-2.5"
-            rel="noopener noreferrer"
-          >
-            <TooltipTrigger asChild>
-              <div className="w-12 h-8 sm:w-16 sm:h-10 me-3 flex items-center justify-center">
-                <Image
-                  src={logoSrc}
-                  alt={`${brand.displayName} Logo`}
-                  width={60}
-                  height={40}
-                  priority
-                  className="w-full h-full object-contain"
-                />
+      {logoTooltip ? (
+        <TooltipProvider>
+          <Tooltip>
+            <Link
+              href="/home"
+              className="flex items-center ps-2.5"
+              rel="noopener noreferrer"
+            >
+              <TooltipTrigger asChild>{logoImage}</TooltipTrigger>
+            </Link>
+            <TooltipContent className="bg-gray-200 font-black" side="left">
+              <TooltipArrow className="fill-gray-200" />
+              <div className="flex flex-col gap-1">
+                {logoTooltip.href ? (
+                  <a
+                    className={`text-black text-base ${Londrina.className}`}
+                    href={logoTooltip.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {logoTooltip.text}
+                    <FaExternalLinkAlt className="inline ml-1 mb-1" />
+                  </a>
+                ) : (
+                  <span className={`text-black text-base ${Londrina.className}`}>
+                    {logoTooltip.text}
+                  </span>
+                )}
               </div>
-            </TooltipTrigger>
-          </Link>
-          <TooltipContent className="bg-gray-200 font-black" side="left">
-            <TooltipArrow className="fill-gray-200" />
-            <div className="flex flex-col gap-1">
-              <a
-                className={`text-black text-base ${Londrina.className}`}
-                href="https://nouns.wtf"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                wtf is nouns? <FaExternalLinkAlt className="inline ml-1 mb-1" />
-              </a>
-            </div>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : (
+        <Link
+          href="/home"
+          className="flex items-center ps-2.5"
+          rel="noopener noreferrer"
+        >
+          {logoImage}
+        </Link>
+      )}
 
       {false && (
         <span className="self-center text-xl font-semibold whitespace-nowrap dark:text-white">

--- a/src/config/clanker/clanker.navigation.ts
+++ b/src/config/clanker/clanker.navigation.ts
@@ -1,6 +1,10 @@
 import { NavigationConfig } from "../systemConfig";
 
 export const clankerNavigation: NavigationConfig = {
+  logoTooltip: {
+    text: "clanker.world",
+    href: "https://www.clanker.world",
+  },
   items: [
     { id: 'home', label: 'Home', href: '/home', icon: 'home' },
     { id: 'notifications', label: 'Notifications', href: '/notifications', icon: 'notifications', requiresAuth: true },

--- a/src/config/nouns/nouns.navigation.ts
+++ b/src/config/nouns/nouns.navigation.ts
@@ -1,6 +1,10 @@
 import { NavigationConfig } from "../systemConfig";
 
 export const nounsNavigation: NavigationConfig = {
+  logoTooltip: {
+    text: "wtf is nouns?",
+    href: "https://nouns.wtf",
+  },
   items: [
     { id: 'home', label: 'Home', href: '/home', icon: 'home' },
     { id: 'explore', label: 'Explore', href: '/explore', icon: 'explore' },

--- a/src/config/systemConfig.ts
+++ b/src/config/systemConfig.ts
@@ -130,6 +130,12 @@ export interface HomePageConfig {
 
 export interface NavigationConfig {
   items: NavigationItem[];
+  logoTooltip?: LogoTooltipConfig;
+}
+
+export interface LogoTooltipConfig {
+  text: string;
+  href?: string;
 }
 
 export interface NavigationItem {


### PR DESCRIPTION
## Summary
- extend navigation configuration to support an optional logo tooltip
- update the brand header to render the tooltip only when configured
- configure nouns and clanker spaces with their respective tooltip text and links

## Testing
- yarn lint *(fails: package missing from lockfile; install required)*

------
https://chatgpt.com/codex/tasks/task_e_690d23630ac8832580618538839defc2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logo tooltips are now dynamically configured and navigation-aware. Tooltip content varies by section and includes contextual information with optional clickable links, replacing the previous static tooltip approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->