### PR TITLE
Remove tooltip from BrandHeader logo

### DIFF
--- a/src/common/components/molecules/BrandHeader.tsx
+++ b/src/common/components/molecules/BrandHeader.tsx
@@ -1,58 +1,29 @@
 import React from "react";
 import Link from "next/link";
 import Image from "next/image";
-import {
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "../atoms/tooltip";
-import { Tooltip, TooltipArrow } from "@radix-ui/react-tooltip";
-import { FaExternalLinkAlt } from "react-icons/fa";
-import { Londrina_Solid } from "next/font/google";
 import { loadSystemConfig } from "@/config";
-
-const Londrina = Londrina_Solid({ subsets: ["latin"], weight: "400" });
 
 const BrandHeader = () => {
   const { assets, brand } = loadSystemConfig();
   const logoSrc = assets.logos.icon || assets.logos.main;
   return (
     <>
-      <TooltipProvider>
-        <Tooltip>
-          <Link
-            href="/home"
-            className="flex items-center ps-2.5"
-            rel="noopener noreferrer"
-          >
-            <TooltipTrigger asChild>
-              <div className="w-12 h-8 sm:w-16 sm:h-10 me-3 flex items-center justify-center">
-                <Image
-                  src={logoSrc}
-                  alt={`${brand.displayName} Logo`}
-                  width={60}
-                  height={40}
-                  priority
-                  className="w-full h-full object-contain"
-                />
-              </div>
-            </TooltipTrigger>
-          </Link>
-          <TooltipContent className="bg-gray-200 font-black" side="left">
-            <TooltipArrow className="fill-gray-200" />
-            <div className="flex flex-col gap-1">
-              <a
-                className={`text-black text-base ${Londrina.className}`}
-                href="https://nouns.wtf"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                wtf is nouns? <FaExternalLinkAlt className="inline ml-1 mb-1" />
-              </a>
-            </div>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <Link
+        href="/home"
+        className="flex items-center ps-2.5"
+        rel="noopener noreferrer"
+      >
+        <div className="w-12 h-8 sm:w-16 sm:h-10 me-3 flex items-center justify-center">
+          <Image
+            src={logoSrc}
+            alt={`${brand.displayName} Logo`}
+            width={60}
+            height={40}
+            priority
+            className="w-full h-full object-contain"
+          />
+        </div>
+      </Link>
 
       {false && (
         <span className="self-center text-xl font-semibold whitespace-nowrap dark:text-white">


### PR DESCRIPTION
## Summary
- remove the tooltip wrapper around the nav logo so hovering the brand icon shows no tooltip
- clean up unused imports left over from the tooltip implementation

## Testing
- yarn lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e1e1102748325b1515b8b1b215d5c)