### PR TITLE
 YouTube Embed Improvements

### DIFF
--- a/src/common/lib/utils/youtubeUtils.ts
+++ b/src/common/lib/utils/youtubeUtils.ts
@@ -1,0 +1,29 @@
+// Utility for detecting and extracting YouTube IDs
+export function getYouTubeId(url: string): string | null {
+  try {
+    const urlObj = new URL(url);
+    // youtube.com/watch?v=ID
+    if (urlObj.hostname.includes('youtube.com')) {
+      const v = urlObj.searchParams.get('v');
+      if (v && /^[\w-]{11}$/.test(v)) return v;
+      // /embed/ID ou /v/ID
+      const pathMatch = urlObj.pathname.match(/\/(?:embed|v)\/([\w-]+)/);
+      if (pathMatch && /^[\w-]{11}$/.test(pathMatch[1])) return pathMatch[1];
+      // /shorts/ID
+      const shortsMatch = urlObj.pathname.match(/\/shorts\/([\w-]+)/);
+      if (shortsMatch && /^[\w-]{11}$/.test(shortsMatch[1])) return shortsMatch[1];
+    }
+    // youtu.be/ID
+    if (urlObj.hostname === 'youtu.be') {
+      const id = urlObj.pathname.split('/')[1]?.split('?')[0];
+      if (id && /^[\w-]{11}$/.test(id)) return id;
+    }
+  } catch {
+    // Invalid URL
+  }
+  return null;
+}
+
+export function isYouTubeUrl(url: string): boolean {
+  return getYouTubeId(url) !== null;
+}

--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -640,8 +640,8 @@ const CastBodyComponent = ({
       {cast.text && (
         <div className={isDetailView ? "text-lg leading-[1.4]" : "text-base leading-[1.4]"}>
           <SafeExpandableText maxLines={maxLines || (isDetailView ? null : 10)} style={castTextStyle}>
-          {/* Remove YouTube links from text */}
-            {cast.text.replace(/https?:\/\/(www\.)?(youtube\.com\/watch\?v=[\w-]{11}|youtu\.be\/[\w-]{11})/g, "")}
+            {/* Remove YouTube links (including Shorts) from the text */}
+            {cast.text.replace(/https?:\/\/(www\.)?(youtube\.com\/(watch\?v=[\w-]{11}|shorts\/[\w-]{11}|embed\/[\w-]{11}|v\/[\w-]{11})|youtu\.be\/[\w-]{11})/g, "")}
           </SafeExpandableText>
         </div>
       )}

--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -176,10 +176,11 @@ const CastEmbedsComponent = ({ cast, onSelectCast }: CastEmbedsProps) => {
 
       {/* Render URLs found in text that aren't already in embeds */}
       {textUrls.map((url, i) => {
-        // Skip if this URL is already in the embeds
+        // Skip if this URL is already embedded or is a YouTube video.
         const isAlreadyEmbedded = embedUrls.some((embed) => isEmbedUrl(embed) && embed.url === url);
+        const isYouTubeUrl = url.includes("youtube.com/watch?v=") || url.includes("youtu.be/");
 
-        if (isAlreadyEmbedded) {
+        if (isAlreadyEmbedded || isYouTubeUrl) {
           return null;
         }
 
@@ -639,7 +640,8 @@ const CastBodyComponent = ({
       {cast.text && (
         <div className={isDetailView ? "text-lg leading-[1.4]" : "text-base leading-[1.4]"}>
           <SafeExpandableText maxLines={maxLines || (isDetailView ? null : 10)} style={castTextStyle}>
-            {cast.text}
+          {/* Remove YouTube links from text */}
+            {cast.text.replace(/https?:\/\/(www\.)?(youtube\.com\/watch\?v=[\w-]{11}|youtu\.be\/[\w-]{11})/g, "")}
           </SafeExpandableText>
         </div>
       )}

--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -30,6 +30,7 @@ import { FaReply } from "react-icons/fa6";
 import { IoMdShare } from "react-icons/io";
 import CreateCast, { DraftType } from "./CreateCast";
 import { renderEmbedForUrl, type CastEmbed } from "./Embeds";
+import { isYouTubeUrl } from "@/common/lib/utils/youtubeUtils";
 import { AnalyticsEvent } from "@/common/constants/analyticsEvents";
 import { useToastStore } from "@/common/data/stores/toastStore";
 
@@ -176,19 +177,15 @@ const CastEmbedsComponent = ({ cast, onSelectCast }: CastEmbedsProps) => {
 
       {/* Render URLs found in text that aren't already in embeds */}
       {textUrls.map((url, i) => {
-        // Skip if this URL is already embedded or is a YouTube video.
+        // Skip if this URL is already embedded or is a YouTube
         const isAlreadyEmbedded = embedUrls.some((embed) => isEmbedUrl(embed) && embed.url === url);
-        const isYouTubeUrl = url.includes("youtube.com/watch?v=") || url.includes("youtu.be/");
-
-        if (isAlreadyEmbedded || isYouTubeUrl) {
+        if (isAlreadyEmbedded || isYouTubeUrl(url)) {
           return null;
         }
-
         const embedData: CastEmbed = {
           url: url,
           key: url,
         };
-
         return (
           <div
             key={`text-url-${i}`}
@@ -640,8 +637,8 @@ const CastBodyComponent = ({
       {cast.text && (
         <div className={isDetailView ? "text-lg leading-[1.4]" : "text-base leading-[1.4]"}>
           <SafeExpandableText maxLines={maxLines || (isDetailView ? null : 10)} style={castTextStyle}>
-            {/* Remove YouTube links (including Shorts) from the text */}
-            {cast.text.replace(/https?:\/\/(www\.)?(youtube\.com\/(watch\?v=[\w-]{11}|shorts\/[\w-]{11}|embed\/[\w-]{11}|v\/[\w-]{11})|youtu\.be\/[\w-]{11})/g, "")}
+           {/* Remove only YouTube URLs using this utility, preserving other links and avoiding double spaces */}
+            {cast.text.replace(/https?:\/\/[^\s]+/g, (url) => isYouTubeUrl(url) ? "" : url).replace(/\s{2,}/g, " ").trim()}
           </SafeExpandableText>
         </div>
       )}

--- a/src/fidgets/farcaster/components/Embeds/OpenGraphEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/OpenGraphEmbed.tsx
@@ -44,19 +44,22 @@ const OpenGraphEmbed: React.FC<OpenGraphEmbedProps> = ({ url }) => {
     fetchOGData();
   }, [url]);
 
-  // Function to extract the YouTube video ID.
+// Function to extract the ID of a YouTube video, including Shorts.
   const getYouTubeId = (link: string) => {
     try {
-      // For links like https://www.youtube.com/watch?v=ID
       const urlObj = new URL(link);
       if (urlObj.hostname.includes('youtube.com')) {
+        // watch?v=ID
         const v = urlObj.searchParams.get('v');
         if (v && v.length === 11) return v;
-        // For links like /embed/ID or /v/ID
-        const pathMatch = urlObj.pathname.match(/\/embed\/([\w-]{11})|\/v\/([\w-]{11})/);
-        if (pathMatch) return pathMatch[1] || pathMatch[2];
+        // /embed/ID ou /v/ID
+        const pathMatch = urlObj.pathname.match(/\/(embed|v)\/([\w-]{11})/);
+        if (pathMatch) return pathMatch[2];
+        // /shorts/ID
+        const shortsMatch = urlObj.pathname.match(/\/shorts\/([\w-]{11})/);
+        if (shortsMatch) return shortsMatch[1];
       }
-      // For links like https://youtu.be/ID
+      // youtu.be/ID
       if (urlObj.hostname === 'youtu.be') {
         const id = urlObj.pathname.split('/')[1];
         if (id && id.length === 11) return id;

--- a/src/fidgets/farcaster/components/Embeds/OpenGraphEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/OpenGraphEmbed.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import Image from "next/image";
 
 interface OpenGraphEmbedProps {
@@ -43,6 +43,47 @@ const OpenGraphEmbed: React.FC<OpenGraphEmbedProps> = ({ url }) => {
 
     fetchOGData();
   }, [url]);
+
+  // Function to extract the YouTube video ID.
+  const getYouTubeId = (link: string) => {
+    try {
+      // For links like https://www.youtube.com/watch?v=ID
+      const urlObj = new URL(link);
+      if (urlObj.hostname.includes('youtube.com')) {
+        const v = urlObj.searchParams.get('v');
+        if (v && v.length === 11) return v;
+        // For links like /embed/ID or /v/ID
+        const pathMatch = urlObj.pathname.match(/\/embed\/([\w-]{11})|\/v\/([\w-]{11})/);
+        if (pathMatch) return pathMatch[1] || pathMatch[2];
+      }
+      // For links like https://youtu.be/ID
+      if (urlObj.hostname === 'youtu.be') {
+        const id = urlObj.pathname.split('/')[1];
+        if (id && id.length === 11) return id;
+      }
+    } catch {
+      // Ignore invalid URLs
+    }
+    return null;
+  };
+
+  const youtubeId = getYouTubeId(url);
+
+  if (youtubeId) {
+    return (
+  <div className="w-full max-w-full aspect-video rounded-xl overflow-hidden">
+          <iframe
+            src={`https://www.youtube.com/embed/${youtubeId}`}
+            title="YouTube video player"
+            className="w-full h-full"
+            frameBorder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+          ></iframe>
+        </div>
+     
+    );
+  }
 
   if (isLoading) {
     return (

--- a/src/fidgets/farcaster/components/Embeds/OpenGraphEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/OpenGraphEmbed.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import Image from "next/image";
+import { getYouTubeId, isYouTubeUrl } from "@/common/lib/utils/youtubeUtils";
 
 interface OpenGraphEmbedProps {
   url: string;
@@ -19,20 +20,20 @@ const OpenGraphEmbed: React.FC<OpenGraphEmbedProps> = ({ url }) => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (isYouTubeUrl(url)) {
+      setIsLoading(false);
+      return;
+    }
     const fetchOGData = async () => {
       try {
         setIsLoading(true);
-
         const response = await fetch(
           `/api/opengraph?url=${encodeURIComponent(url)}`
         );
-
         if (!response.ok) {
           throw new Error(`Failed to fetch: ${response.statusText}`);
         }
-
         const data = await response.json();
-
         setOgData(data);
       } catch (err) {
         setError(err instanceof Error ? err.message : "Unknown error");
@@ -40,51 +41,21 @@ const OpenGraphEmbed: React.FC<OpenGraphEmbedProps> = ({ url }) => {
         setIsLoading(false);
       }
     };
-
     fetchOGData();
   }, [url]);
 
-// Function to extract the ID of a YouTube video, including Shorts.
-  const getYouTubeId = (link: string) => {
-    try {
-      const urlObj = new URL(link);
-      if (urlObj.hostname.includes('youtube.com')) {
-        // watch?v=ID
-        const v = urlObj.searchParams.get('v');
-        if (v && v.length === 11) return v;
-        // /embed/ID ou /v/ID
-        const pathMatch = urlObj.pathname.match(/\/(embed|v)\/([\w-]{11})/);
-        if (pathMatch) return pathMatch[2];
-        // /shorts/ID
-        const shortsMatch = urlObj.pathname.match(/\/shorts\/([\w-]{11})/);
-        if (shortsMatch) return shortsMatch[1];
-      }
-      // youtu.be/ID
-      if (urlObj.hostname === 'youtu.be') {
-        const id = urlObj.pathname.split('/')[1];
-        if (id && id.length === 11) return id;
-      }
-    } catch {
-      // Ignore invalid URLs
-    }
-    return null;
-  };
-
   const youtubeId = getYouTubeId(url);
-
   if (youtubeId) {
     return (
-  <div className="w-full max-w-full aspect-video rounded-xl overflow-hidden">
-          <iframe
-            src={`https://www.youtube.com/embed/${youtubeId}`}
-            title="YouTube video player"
-            className="w-full h-full"
-            frameBorder="0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowFullScreen
-          ></iframe>
-        </div>
-     
+      <div className="w-full max-w-full aspect-video rounded-xl overflow-hidden">
+        <iframe
+          src={`https://www.youtube.com/embed/${youtubeId}`}
+          title="YouTube video player"
+          className="w-full h-full border-0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+        ></iframe>
+      </div>
     );
   }
 

--- a/src/fidgets/farcaster/components/Embeds/OpenGraphEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/OpenGraphEmbed.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import Image from "next/image";
-import { getYouTubeId, isYouTubeUrl } from "@/common/lib/utils/youtubeUtils";
+import { getYouTubeId } from "@/common/lib/utils/youtubeUtils";
 
 interface OpenGraphEmbedProps {
   url: string;
@@ -19,8 +19,13 @@ const OpenGraphEmbed: React.FC<OpenGraphEmbedProps> = ({ url }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // Extract YouTube ID once and check if it's a YouTube URL
+  const youtubeId = getYouTubeId(url);
+  const isYouTube = youtubeId !== null;
+
   useEffect(() => {
-    if (isYouTubeUrl(url)) {
+    // Skip OpenGraph fetch for YouTube URLs since we render the embed directly
+    if (isYouTube) {
       setIsLoading(false);
       return;
     }
@@ -42,9 +47,7 @@ const OpenGraphEmbed: React.FC<OpenGraphEmbedProps> = ({ url }) => {
       }
     };
     fetchOGData();
-  }, [url]);
-
-  const youtubeId = getYouTubeId(url);
+  }, [url, isYouTube]);
   if (youtubeId) {
     return (
       <div className="w-full max-w-full aspect-video rounded-xl overflow-hidden">


### PR DESCRIPTION


## What changed?

- No more duplicate YouTube link above the video — just the player is shown.
- If the video link is in the text, the system removes it so it doesn't show twice.
- The video container doesn't have a width limit anymore, so it grows with the available space.
- If there's an error fetching YouTube data, no fallback link is shown, just the player (or nothing).

## How to test

1. Run the project:

   ```bash
   yarn dev
   ```

2. Post or view a cast with a YouTube link (example: https://www.youtube.com/watch?v=kFO0aREV3y0).

3. Check:
   - The video shows up big and responsive.
   - The YouTube link doesn't show above the video.
   - Other links still show up as usual.

## Notes

- The system covers the most common YouTube link formats (`youtube.com/watch?v=ID` and `youtu.be/ID`).
- If you need to handle other media types, it's easy to adapt.

## Changed files

- `src/fidgets/farcaster/components/Embeds/OpenGraphEmbed.tsx`
- `src/fidgets/farcaster/components/CastRow.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * YouTube videos now render as embedded players directly in the feed instead of link previews.
  * YouTube links are removed from cast text when the video is embedded, preventing duplicate links and normalizing spacing.
  * YouTube links no longer trigger external metadata fetches, reducing redundant previews and load.

* **Bug Fixes**
  * Prevents YouTube links from appearing both as text and as separate embeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->