### PR TITLE
Spotify Embed Cleanup 

### DIFF
--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -619,17 +619,16 @@ const EnhancedLinkify: React.FC<{ children: string; style?: React.CSSProperties 
   };
 
   // Remove links from Spotify in the rendered text
+  const SPOTIFY_TRACK_URL_REGEX = /https?:\/\/open\.spotify\.com\/track\/[A-Za-z0-9]+/;
+  function hasSpotifyHref(element: unknown): boolean {
+    if (!React.isValidElement(element)) return false;
+    const href = (element.props as { href?: string })?.href;
+    return typeof href === "string" && SPOTIFY_TRACK_URL_REGEX.test(href);
+  }
   const filtered = linkifyText(children).filter((part) => {
-    if (typeof part === "string" && part.includes("open.spotify.com/track")) return false;
-    if (
-      React.isValidElement(part) &&
-      part.props &&
-      typeof (part.props as { href?: unknown }).href === "string" &&
-      ((part.props as { href?: string }).href?.includes("open.spotify.com/track"))
-    ) {
-      return false;
-    }
-    return true;
+  if (typeof part === "string" && SPOTIFY_TRACK_URL_REGEX.test(part)) return false;
+  if (hasSpotifyHref(part) === true) return false;
+  return true;
   });
   return <span style={style}>{filtered}</span>;
 };

--- a/src/fidgets/farcaster/components/Embeds/SpotifyEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/SpotifyEmbed.tsx
@@ -16,11 +16,12 @@ const SpotifyEmbed: React.FC<SpotifyEmbedProps> = ({ url }) => {
       data-testid="embed-iframe"
       style={{ borderRadius: "12px" }}
       src={`https://open.spotify.com/embed/track/${trackId}?utm_source=generator&theme=0`}
+      width="100%"
       height="352"
       allowFullScreen
       allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
       loading="lazy"
-      title="Spotify Player"
+      title={`Spotify Player - Track ${trackId}`}
     />
   );
 };

--- a/src/fidgets/farcaster/components/Embeds/SpotifyEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/SpotifyEmbed.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+interface SpotifyEmbedProps {
+  url: string;
+}
+
+const SpotifyEmbed: React.FC<SpotifyEmbedProps> = ({ url }) => {
+  // Extracts the song ID from the link.
+  const match = url.match(/track\/([a-zA-Z0-9]+)/);
+  const trackId = match ? match[1] : null;
+
+  if (!trackId) return null;
+
+  return (
+    <iframe
+      data-testid="embed-iframe"
+      style={{ borderRadius: "12px" }}
+      src={`https://open.spotify.com/embed/track/${trackId}?utm_source=generator&theme=0`}
+      height="352"
+      allowFullScreen
+      allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+      loading="lazy"
+      title="Spotify Player"
+    />
+  );
+};
+
+export default SpotifyEmbed;

--- a/src/fidgets/farcaster/components/Embeds/index.tsx
+++ b/src/fidgets/farcaster/components/Embeds/index.tsx
@@ -62,7 +62,7 @@ export const renderEmbedForUrl = (
     return <NounsBuildEmbed url={url} key={key} />;
   } else if (url.includes("paragraph.xyz") || url.includes("pgrph.xyz")) {
     return <ParagraphXyzEmbed url={url} key={key} />;
-  } else if (url.includes("open.spotify.com/track")) {
+  } else if (url.startsWith("https://open.spotify.com/track")) {
     return <SpotifyEmbed url={url} key={key} />;
   } else if (!isImageUrl(url)) {
     // Use smart frame detection to render Frame v2 when possible

--- a/src/fidgets/farcaster/components/Embeds/index.tsx
+++ b/src/fidgets/farcaster/components/Embeds/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import SpotifyEmbed from "./SpotifyEmbed";
 import EmbededCast from "./EmbededCast";
 import OnchainEmbed from "./OnchainEmbed";
 import TweetEmbed from "./TweetEmbed";
@@ -61,6 +62,8 @@ export const renderEmbedForUrl = (
     return <NounsBuildEmbed url={url} key={key} />;
   } else if (url.includes("paragraph.xyz") || url.includes("pgrph.xyz")) {
     return <ParagraphXyzEmbed url={url} key={key} />;
+  } else if (url.includes("open.spotify.com/track")) {
+    return <SpotifyEmbed url={url} key={key} />;
   } else if (!isImageUrl(url)) {
     // Use smart frame detection to render Frame v2 when possible
     // Falls back to legacy frame system if Frame v2 metadata is not detected


### PR DESCRIPTION

## Changes made

### src/fidgets/farcaster/components/Embeds/SpotifyEmbed.tsx

- Created component to render Spotify embed with official style.

### src/fidgets/farcaster/components/Embeds/index.tsx

- Added Spotify support in `renderEmbedForUrl`, showing the player for `open.spotify.com/track` links.

### src/fidgets/farcaster/components/CastRow.tsx

- Filtered Spotify links from cast text to avoid duplicate display.
- Improved logic to ensure the link does not appear in text or embeds when the player is present.
- Fixed typing when accessing React element properties.

## Result

- Spotify links now only show the embed player, with no duplicate link in the feed text.
- Cleaner and more consistent visual for posts with Spotify music.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spotify tracks now embed directly in casts for inline playback and discovery.

* **Bug Fixes**
  * Spotify track URLs are removed from plain text/linkified render paths so tracks appear only as embeds.
  * Improved embed rendering to avoid empty or duplicate embed areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->