### PR TITLE
Add follow controls to directory fidget

### DIFF
--- a/src/fidgets/token/Directory/Directory.tsx
+++ b/src/fidgets/token/Directory/Directory.tsx
@@ -267,22 +267,6 @@ const Directory: React.FC<
     setCurrentPage(1);
   }, [includeFilter, currentSort]);
 
-  const hasFarcasterMembers = useMemo(
-    () => (directoryData.members ?? []).some((member) => typeof member.fid === "number" && member.fid > 0),
-    [directoryData.members],
-  );
-
-  const viewerContextHydrated = useMemo(() => {
-    if (!hasFarcasterMembers) {
-      return true;
-    }
-
-    const members = directoryData.members ?? [];
-    return members.some(
-      (member) => typeof member.fid === "number" && member.fid > 0 && member.viewerContext != null,
-    );
-  }, [directoryData.members, hasFarcasterMembers]);
-
   useEffect(() => {
     if (viewerFid <= 0) {
       return;
@@ -417,10 +401,6 @@ const Directory: React.FC<
       if (lastViewerContextFid !== viewerFid) {
         return true;
       }
-
-      if (!viewerContextHydrated) {
-        return true;
-      }
     } else if (lastViewerContextFid !== null) {
       return true;
     }
@@ -458,7 +438,6 @@ const Directory: React.FC<
     settings.channelFilter,
     viewerFid,
     lastViewerContextFid,
-    viewerContextHydrated,
   ]);
 
   const stripViewerContext = useCallback(

--- a/src/fidgets/token/Directory/components/DirectoryCardView.tsx
+++ b/src/fidgets/token/Directory/components/DirectoryCardView.tsx
@@ -5,7 +5,12 @@ import {
   AvatarImage,
 } from "@/common/components/atoms/avatar";
 import BoringAvatar from "boring-avatars";
-import type { DirectoryMemberData, DirectoryFidgetSettings, DirectoryNetwork, DirectoryIncludeOption } from "../types";
+import type {
+  DirectoryMemberData,
+  DirectoryFidgetSettings,
+  DirectoryNetwork,
+  DirectoryIncludeOption,
+} from "../types";
 import { ProfileLink } from "./ProfileLink";
 import { BadgeIcons } from "./BadgeIcons";
 import {
@@ -17,6 +22,10 @@ import {
   formatTokenBalance,
 } from "../utils";
 import { buildEtherscanUrl, getBlockExplorerLink } from "@/common/data/api/token/utils";
+import {
+  DirectoryFollowButton,
+  type DirectoryFollowButtonProps,
+} from "./DirectoryFollowButton";
 
 export type DirectoryCardViewProps = {
   members: DirectoryMemberData[];
@@ -26,6 +35,8 @@ export type DirectoryCardViewProps = {
   headingFontFamilyStyle: React.CSSProperties;
   network: DirectoryNetwork;
   includeFilter: DirectoryIncludeOption;
+  viewerFid: number;
+  signer: DirectoryFollowButtonProps["signer"];
 };
 
 export const DirectoryCardView: React.FC<DirectoryCardViewProps> = ({
@@ -36,6 +47,8 @@ export const DirectoryCardView: React.FC<DirectoryCardViewProps> = ({
   headingFontFamilyStyle,
   network,
   includeFilter,
+  viewerFid,
+  signer,
 }) => {
   return (
     <div className="grid grid-cols-1 gap-4 py-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -136,6 +149,14 @@ export const DirectoryCardView: React.FC<DirectoryCardViewProps> = ({
                 githubHandle={member.githubHandle}
                 githubUrl={member.githubUrl}
                 size={18}
+              />
+            </div>
+            <div className="pointer-events-none absolute bottom-3 right-3 z-10">
+              <DirectoryFollowButton
+                member={member}
+                viewerFid={viewerFid}
+                signer={signer}
+                className="pointer-events-auto px-3 py-1 text-xs font-semibold"
               />
             </div>
           </div>

--- a/src/fidgets/token/Directory/components/DirectoryFollowButton.tsx
+++ b/src/fidgets/token/Directory/components/DirectoryFollowButton.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Button } from "@/common/components/atoms/button";
+import type { DirectoryMemberData } from "../types";
+import { followUser, unfollowUser } from "@/fidgets/farcaster/utils";
+
+export type DirectoryFollowButtonProps = {
+  member: DirectoryMemberData;
+  viewerFid: number;
+  signer: Parameters<typeof followUser>[2] | undefined;
+  className?: string;
+};
+
+export const DirectoryFollowButton: React.FC<DirectoryFollowButtonProps> = ({
+  member,
+  viewerFid,
+  signer,
+  className,
+}) => {
+  const canFollow = useMemo(() => {
+    return (
+      Boolean(signer) &&
+      typeof viewerFid === "number" &&
+      viewerFid > 0 &&
+      typeof member.fid === "number" &&
+      member.fid > 0 &&
+      member.fid !== viewerFid
+    );
+  }, [member.fid, signer, viewerFid]);
+
+  const initialFollowing = member.viewerContext?.following ?? false;
+  const [isFollowing, setIsFollowing] = useState<boolean>(initialFollowing);
+  const [isHovering, setIsHovering] = useState<boolean>(false);
+  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
+
+  useEffect(() => {
+    setIsFollowing(initialFollowing);
+  }, [initialFollowing, member.fid]);
+
+  if (!canFollow) {
+    return null;
+  }
+
+  const handleClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (!signer || typeof member.fid !== "number" || member.fid <= 0) {
+      return;
+    }
+
+    const targetFid = member.fid;
+    const nextFollowing = !isFollowing;
+
+    setStatus("loading");
+    setIsFollowing(nextFollowing);
+
+    try {
+      const success = nextFollowing
+        ? await followUser(targetFid, viewerFid, signer)
+        : await unfollowUser(targetFid, viewerFid, signer);
+
+      if (!success) {
+        throw new Error("Failed to update follow status");
+      }
+
+      setStatus("idle");
+    } catch (error) {
+      console.error("Directory follow toggle failed", error);
+      setIsFollowing(!nextFollowing);
+      setStatus("error");
+      setTimeout(() => setStatus("idle"), 3000);
+    }
+  };
+
+  const label = status === "loading"
+    ? "..."
+    : isFollowing
+      ? isHovering
+        ? "Unfollow"
+        : "Following"
+      : "Follow";
+
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant={isFollowing ? "secondary" : "primary"}
+      disabled={status === "loading"}
+      onClick={handleClick}
+      onMouseEnter={() => setIsHovering(true)}
+      onMouseLeave={() => setIsHovering(false)}
+      className={className}
+    >
+      {label}
+    </Button>
+  );
+};

--- a/src/fidgets/token/Directory/components/DirectoryListView.tsx
+++ b/src/fidgets/token/Directory/components/DirectoryListView.tsx
@@ -5,7 +5,12 @@ import {
   AvatarImage,
 } from "@/common/components/atoms/avatar";
 import BoringAvatar from "boring-avatars";
-import type { DirectoryMemberData, DirectoryFidgetSettings, DirectoryNetwork, DirectoryIncludeOption } from "../types";
+import type {
+  DirectoryMemberData,
+  DirectoryFidgetSettings,
+  DirectoryNetwork,
+  DirectoryIncludeOption,
+} from "../types";
 import { ProfileLink } from "./ProfileLink";
 import { BadgeIcons } from "./BadgeIcons";
 import {
@@ -17,6 +22,10 @@ import {
   formatTokenBalance,
 } from "../utils";
 import { buildEtherscanUrl, getBlockExplorerLink } from "@/common/data/api/token/utils";
+import {
+  DirectoryFollowButton,
+  type DirectoryFollowButtonProps,
+} from "./DirectoryFollowButton";
 
 export type DirectoryListViewProps = {
   members: DirectoryMemberData[];
@@ -25,6 +34,8 @@ export type DirectoryListViewProps = {
   headingTextStyle: React.CSSProperties;
   network: DirectoryNetwork;
   includeFilter: DirectoryIncludeOption;
+  viewerFid: number;
+  signer: DirectoryFollowButtonProps["signer"];
 };
 
 export const DirectoryListView: React.FC<DirectoryListViewProps> = ({
@@ -34,6 +45,8 @@ export const DirectoryListView: React.FC<DirectoryListViewProps> = ({
   headingTextStyle,
   network,
   includeFilter,
+  viewerFid,
+  signer,
 }) => {
   return (
     <ul className="divide-y divide-black/5">
@@ -107,19 +120,27 @@ export const DirectoryListView: React.FC<DirectoryListViewProps> = ({
                 <span className="block truncate text-xs text-muted-foreground">{secondaryLabel}</span>
               )}
             </div>
-            <div className="flex flex-col items-end gap-1 text-right text-xs text-muted-foreground">
-              {(settings.source ?? "tokenHolders") === "tokenHolders" && (
-                <span className="font-semibold" style={headingTextStyle}>
-                  {formatTokenBalance(member.balanceFormatted)}
-                  {tokenSymbol ? ` ${tokenSymbol}` : ""}
-                </span>
-              )}
-              {typeof member.followers === "number" && (
-                <span>{`${member.followers.toLocaleString()} followers`}</span>
-              )}
-              {(settings.source ?? "tokenHolders") === "tokenHolders" && lastActivity && (
-                <span>{lastActivity}</span>
-              )}
+            <div className="ml-auto flex items-center gap-3">
+              <DirectoryFollowButton
+                member={member}
+                viewerFid={viewerFid}
+                signer={signer}
+                className="px-3 py-1 text-xs font-semibold"
+              />
+              <div className="flex flex-col items-end gap-1 text-right text-xs text-muted-foreground">
+                {(settings.source ?? "tokenHolders") === "tokenHolders" && (
+                  <span className="font-semibold" style={headingTextStyle}>
+                    {formatTokenBalance(member.balanceFormatted)}
+                    {tokenSymbol ? ` ${tokenSymbol}` : ""}
+                  </span>
+                )}
+                {typeof member.followers === "number" && (
+                  <span>{`${member.followers.toLocaleString()} followers`}</span>
+                )}
+                {(settings.source ?? "tokenHolders") === "tokenHolders" && lastActivity && (
+                  <span>{lastActivity}</span>
+                )}
+              </div>
             </div>
           </li>
         );

--- a/src/fidgets/token/Directory/types.ts
+++ b/src/fidgets/token/Directory/types.ts
@@ -13,6 +13,10 @@ export type DirectoryChannelFilterOption = "members" | "followers" | "all";
 export type CsvTypeOption = "address" | "fid" | "username";
 export type CsvSortOption = "followers" | "csvOrder";
 
+export type DirectoryMemberViewerContext = {
+  following?: boolean | null;
+};
+
 export interface DirectoryMemberData {
   address: string;
   balanceRaw: string;
@@ -31,6 +35,7 @@ export interface DirectoryMemberData {
   xUrl?: string | null;
   githubHandle?: string | null;
   githubUrl?: string | null;
+  viewerContext?: DirectoryMemberViewerContext | null;
 }
 
 export interface DirectoryFidgetData extends FidgetData {

--- a/src/fidgets/token/Directory/utils.ts
+++ b/src/fidgets/token/Directory/utils.ts
@@ -155,6 +155,7 @@ export {
   getNestedUser,
   mapNeynarUserToMember,
   createDefaultMemberForCsv,
+  extractViewerContext,
   type NeynarUser,
 } from "./utils/memberData";
 

--- a/src/fidgets/token/Directory/utils/memberData.ts
+++ b/src/fidgets/token/Directory/utils/memberData.ts
@@ -3,7 +3,10 @@ import {
   extractNeynarPrimaryAddress,
   extractNeynarSocialAccounts,
 } from "@/common/data/api/token/utils";
-import type { DirectoryMemberData } from "../types";
+import type {
+  DirectoryMemberData,
+  DirectoryMemberViewerContext,
+} from "../types";
 
 /**
  * Type for Neynar user objects
@@ -14,7 +17,27 @@ export type NeynarUser = {
   display_name?: string | null;
   pfp_url?: string | null;
   follower_count?: number | null;
+  viewer_context?: {
+    following?: boolean | null;
+  } | null;
 };
+
+function extractViewerContext(
+  user: NeynarUser | undefined,
+): DirectoryMemberViewerContext | null {
+  if (!user || typeof user !== "object") {
+    return null;
+  }
+  const context = user.viewer_context;
+  if (!context || typeof context !== "object") {
+    return null;
+  }
+  const following = context.following;
+  if (typeof following === "boolean" || following === null) {
+    return { following };
+  }
+  return null;
+}
 
 /**
  * Helper to normalize various user shapes coming from Neynar
@@ -54,6 +77,7 @@ export function mapNeynarUserToMember(u: NeynarUser): DirectoryMemberData {
     xUrl: userXUrl,
     githubHandle: userGithubHandle,
     githubUrl: userGithubUrl,
+    viewerContext: extractViewerContext(u),
   };
 }
 
@@ -84,6 +108,7 @@ export function createDefaultMemberForCsv(
       xUrl: null,
       githubHandle: null,
       githubUrl: null,
+      viewerContext: null,
     };
   }
   if (type === "fid") {
@@ -106,6 +131,7 @@ export function createDefaultMemberForCsv(
       xUrl: null,
       githubHandle: null,
       githubUrl: null,
+      viewerContext: null,
     };
   }
   // address
@@ -128,6 +154,7 @@ export function createDefaultMemberForCsv(
     xUrl: null,
     githubHandle: null,
     githubUrl: null,
+    viewerContext: null,
   };
 }
 

--- a/src/fidgets/token/Directory/utils/memberData.ts
+++ b/src/fidgets/token/Directory/utils/memberData.ts
@@ -22,7 +22,7 @@ export type NeynarUser = {
   } | null;
 };
 
-function extractViewerContext(
+export function extractViewerContext(
   user: NeynarUser | undefined,
 ): DirectoryMemberViewerContext | null {
   if (!user || typeof user !== "object") {


### PR DESCRIPTION
## Summary
- add follow and unfollow controls to the directory card and list layouts via a reusable DirectoryFollowButton
- pass Farcaster viewer information through directory data fetching so member viewer_context is available in the UI
- update the token directory API to accept an optional viewer fid and return viewer follow status alongside members

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917304e02148325bc36b5fd140622d6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added follow/unfollow buttons to directory member cards and list entries
  * Directory now displays your follow status for each member
  * Follow actions integrated with account authentication for seamless interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->