### PR TITLE
Zora embed — normalization and preview

### DIFF
--- a/src/fidgets/farcaster/components/Embeds/ZoraEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/ZoraEmbed.tsx
@@ -1,0 +1,155 @@
+import React, { useEffect, useState } from "react";
+import { parseZoraUrl } from "./zoraUtils";
+
+interface ZoraEmbedProps {
+  url: string;
+}
+
+type OG = {
+  title?: string | null;
+  description?: string | null;
+  image?: string | null;
+  siteName?: string | null;
+  url?: string | null;
+};
+
+const ZoraEmbed: React.FC<ZoraEmbedProps> = ({ url }) => {
+  const [og, setOg] = useState<OG | null>(null);
+  const [loading, setLoading] = useState(true);
+  const parsed = parseZoraUrl(url);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchOG = async () => {
+      if (!parsed) {
+        setLoading(false);
+        return;
+      }
+
+      // Only call opengraph for https pages
+      if (!parsed.pageUrl.startsWith("https://")) {
+        setLoading(false);
+        return;
+      }
+
+      try {
+        setLoading(true);
+        const resp = await fetch(`/api/opengraph?url=${encodeURIComponent(parsed.pageUrl)}`);
+        if (!resp.ok) throw new Error("open graph fetch failed");
+        const data = await resp.json();
+        if (!cancelled) setOg(data);
+      } catch (e) {
+        // ignore
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    fetchOG();
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  // Build trade link - MVP: point to the page URL discovered
+  const tradeUrl = parsed?.pageUrl ?? url;
+
+  if (loading) {
+    return (
+      <div className="border border-gray-200 rounded-lg p-4 w-full max-w-2xl">
+        <div className="animate-pulse">
+          <div className="bg-gray-300 h-4 rounded w-3/4 mb-2"></div>
+          <div className="bg-gray-300 h-3 rounded w-1/2"></div>
+        </div>
+      </div>
+    );
+  }
+
+  if (og && (og.image || og.title)) {
+    const siteLabel = og.siteName || (() => {
+      try { return new URL(tradeUrl).hostname; } catch { return "zora.co"; }
+    })();
+
+    // Try to mimic Zora's card: subtle gray gradient header with inset preview that looks like a framed post
+    return (
+      <div className="w-full max-w-2xl">
+        <div className="bg-white rounded-xl border border-gray-200 overflow-hidden shadow-sm">
+          {/* Header / preview area (gradient) */}
+          <div className="bg-gradient-to-b from-gray-200 via-gray-100 to-gray-100 p-4">
+            <div className="relative mx-auto max-w-3xl">
+              {/* Inner rounded preview card (lighter) */}
+              <a href={tradeUrl} target="_blank" rel="noopener noreferrer" className="block">
+                <div className="mx-auto w-full rounded-lg bg-white shadow-inner" style={{maxWidth: 720}}>
+                  <div className="p-4">
+                    <div className="relative rounded-md overflow-hidden bg-white" style={{minHeight: 120}}>
+                      {og.image ? (
+                        <img src={og.image!} alt={og.title || "Zora preview"} className="object-cover w-full h-48 md:h-40 lg:h-48" />
+                      ) : (
+                        <div className="w-full h-48 bg-gray-100 flex items-center justify-center">
+                          <span className="text-sm text-gray-400">Preview</span>
+                        </div>
+                      )}
+                      {/* top-left badge */}
+                      <div className="absolute left-3 top-3 px-2 py-1 bg-white text-xs font-medium rounded-full text-gray-800">Zora</div>
+                      {/* top-right site text */}
+                      <div className="absolute right-3 top-3 text-xs text-gray-500">{siteLabel}</div>
+                    </div>
+                  </div>
+                </div>
+              </a>
+            </div>
+          </div>
+
+          {/* Footer: title + actions */}
+          <div className="px-4 py-3">
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                {og.title && <div className="font-semibold text-gray-900 text-base line-clamp-2">{og.title}</div>}
+                {og.description && <div className="text-sm text-gray-600 mt-1 line-clamp-2">{og.description}</div>}
+              </div>
+
+              <div className="flex-shrink-0">
+                <a
+                  href={tradeUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center px-3 py-1.5 bg-blue-600 hover:bg-blue-700 text-white text-sm rounded-md"
+                >
+                  Trade
+                </a>
+              </div>
+            </div>
+
+            <div className="mt-3 text-xs text-gray-500">{siteLabel}</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Fallback
+  return (
+    <div className="w-full max-w-2xl bg-white rounded-xl border border-gray-100 p-4 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-sm font-semibold text-gray-900">Zora</div>
+          {parsed?.contract && (
+            <div className="text-xs text-gray-500">{parsed.contract}{parsed?.tokenId ? ` • #${parsed.tokenId}` : ''}</div>
+          )}
+        </div>
+
+        <div>
+          <a
+            href={tradeUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 px-3 py-1.5 bg-blue-600 hover:bg-blue-700 text-white text-sm rounded-lg"
+          >
+            View
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ZoraEmbed;

--- a/src/fidgets/farcaster/components/Embeds/ZoraEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/ZoraEmbed.tsx
@@ -48,7 +48,7 @@ const ZoraEmbed: React.FC<ZoraEmbedProps> = ({ url }) => {
     return () => {
       cancelled = true;
     };
-  }, [url]);
+  }, [url, parsed?.pageUrl]);
 
   // Build trade link - MVP: point to the page URL discovered
   const tradeUrl = parsed?.pageUrl ?? url;
@@ -77,10 +77,10 @@ const ZoraEmbed: React.FC<ZoraEmbedProps> = ({ url }) => {
           <div className="bg-gradient-to-b from-gray-200 via-gray-100 to-gray-100 p-4">
             <div className="relative mx-auto max-w-3xl">
               {/* Inner rounded preview card (lighter) */}
-              <a href={tradeUrl} target="_blank" rel="noopener noreferrer" className="block">
-                <div className="mx-auto w-full rounded-lg bg-white shadow-inner" style={{maxWidth: 720}}>
+              <a href={tradeUrl} target="_blank" rel="noopener noreferrer" className="block" aria-label={og.title ? `View "${og.title}" on ${siteLabel}` : `View on ${siteLabel}`}>
+                <div className="mx-auto w-full rounded-lg bg-white shadow-inner max-w-[720px]">
                   <div className="p-4">
-                    <div className="relative rounded-md overflow-hidden bg-white" style={{minHeight: 120}}>
+                    <div className="relative rounded-md overflow-hidden bg-white min-h-[120px]">
                       {og.image ? (
                         <img src={og.image!} alt={og.title || "Zora preview"} className="object-cover w-full h-48 md:h-40 lg:h-48" />
                       ) : (
@@ -113,13 +113,13 @@ const ZoraEmbed: React.FC<ZoraEmbedProps> = ({ url }) => {
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center px-3 py-1.5 bg-blue-600 hover:bg-blue-700 text-white text-sm rounded-md"
+                  aria-label={`Trade ${og.title || 'on Zora'}`}
                 >
                   Trade
                 </a>
               </div>
             </div>
-
-            <div className="mt-3 text-xs text-gray-500">{siteLabel}</div>
+            {/* siteLabel already shown in preview header */}
           </div>
         </div>
       </div>
@@ -143,6 +143,7 @@ const ZoraEmbed: React.FC<ZoraEmbedProps> = ({ url }) => {
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2 px-3 py-1.5 bg-blue-600 hover:bg-blue-700 text-white text-sm rounded-lg"
+            aria-label={`View ${parsed?.contract ? `contract ${parsed.contract}${parsed?.tokenId ? ` token #${parsed.tokenId}` : ''}` : 'on Zora'}`}
           >
             View
           </a>

--- a/src/fidgets/farcaster/components/Embeds/index.tsx
+++ b/src/fidgets/farcaster/components/Embeds/index.tsx
@@ -60,7 +60,7 @@ export const renderEmbedForUrl = (
     return tweetId ? <TweetEmbed tweetId={tweetId} key={key} /> : null;
   } else if (url.startsWith("https://nouns.build")) {
     return <NounsBuildEmbed url={url} key={key} />;
-  } else if (url.includes("zora.co") || url.startsWith("zoraCoin:") || url.includes("/coin/")) {
+  } else if (url.includes("zora.co") || url.startsWith("zoraCoin:")) {
     return <ZoraEmbed url={url} key={key} />;
   } else if (url.includes("paragraph.xyz") || url.includes("pgrph.xyz")) {
     return <ParagraphXyzEmbed url={url} key={key} />;

--- a/src/fidgets/farcaster/components/Embeds/index.tsx
+++ b/src/fidgets/farcaster/components/Embeds/index.tsx
@@ -7,6 +7,7 @@ import ParagraphXyzEmbed from "./ParagraphXyzEmbed";
 import VideoEmbed from "./VideoEmbed";
 import ImageEmbed from "./ImageEmbed";
 import SmartFrameEmbed from "./SmartFrameEmbed";
+import ZoraEmbed from "./ZoraEmbed";
 import { isImageUrl, isVideoUrl } from "@/common/lib/utils/urls";
 import CreateCastImage from "./createCastImage";
 
@@ -59,6 +60,8 @@ export const renderEmbedForUrl = (
     return tweetId ? <TweetEmbed tweetId={tweetId} key={key} /> : null;
   } else if (url.startsWith("https://nouns.build")) {
     return <NounsBuildEmbed url={url} key={key} />;
+  } else if (url.includes("zora.co") || url.startsWith("zoraCoin:") || url.includes("/coin/")) {
+    return <ZoraEmbed url={url} key={key} />;
   } else if (url.includes("paragraph.xyz") || url.includes("pgrph.xyz")) {
     return <ParagraphXyzEmbed url={url} key={key} />;
   } else if (!isImageUrl(url)) {

--- a/src/fidgets/farcaster/components/Embeds/zoraUtils.ts
+++ b/src/fidgets/farcaster/components/Embeds/zoraUtils.ts
@@ -7,7 +7,7 @@ export const parseZoraUrl = (input: string): { pageUrl: string; contract?: strin
       const contract = parts[0];
       const tokenId = parts[1];
       // Normalize all zoraCoin scheme URLs to use the /coin/ namespace.
-      const contractNormalized = contract ? (contract.includes(":") ? contract : contract) : undefined;
+  const contractNormalized = contract ? contract : undefined;
       const pageUrl = contractNormalized
         ? tokenId
           ? `https://zora.co/coin/${contractNormalized}/${tokenId}`
@@ -56,7 +56,7 @@ export const parseZoraUrl = (input: string): { pageUrl: string; contract?: strin
           tokenId = collectMatch[2];
         }
         // Normalize to coin/<contract>. If the collect path used a namespace (e.g. base:0x...)
-        const contractNormalized = contract ? (contract.includes(":") ? contract : contract) : undefined;
+  const contractNormalized = contract ? contract : undefined;
         const pageUrl = contractNormalized
           ? tokenId
             ? `https://zora.co/coin/${contractNormalized}/${tokenId}`

--- a/src/fidgets/farcaster/components/Embeds/zoraUtils.ts
+++ b/src/fidgets/farcaster/components/Embeds/zoraUtils.ts
@@ -1,0 +1,77 @@
+export const parseZoraUrl = (input: string): { pageUrl: string; contract?: string; tokenId?: string } | null => {
+  try {
+    // Handle zoraCoin scheme: zoraCoin://<contract>[/<tokenId>]
+    if (input.startsWith("zoraCoin:")) {
+      const after = input.replace(/^zoraCoin:\/\//, "");
+      const parts = after.split("/").filter(Boolean);
+      const contract = parts[0];
+      const tokenId = parts[1];
+      // Normalize all zoraCoin scheme URLs to use the /coin/ namespace.
+      const contractNormalized = contract ? (contract.includes(":") ? contract : contract) : undefined;
+      const pageUrl = contractNormalized
+        ? tokenId
+          ? `https://zora.co/coin/${contractNormalized}/${tokenId}`
+          : `https://zora.co/coin/${contractNormalized}`
+        : input;
+      return { pageUrl, contract: contractNormalized, tokenId };
+    }
+
+    const u = new URL(input);
+    const hostname = u.hostname.toLowerCase();
+
+    // Accept zora.co host variants
+    if (hostname.includes("zora.co")) {
+      const decodedPath = decodeURIComponent(u.pathname || "");
+
+      // coin pattern
+      const coinMatch = decodedPath.match(/\/?coin\/((?:[a-zA-Z0-9_-]+:)?0x[a-fA-F0-9]{40})(?:\/(\d+))?/);
+      if (coinMatch) {
+        const contract = coinMatch[1];
+        const tokenId = coinMatch[2];
+        const pageUrl = tokenId ? `https://zora.co/coin/${contract}/${tokenId}` : `https://zora.co/coin/${contract}`;
+        return { pageUrl, contract, tokenId };
+      }
+
+      // tokens pattern (leave as tokens)
+      const tokensMatch = decodedPath.match(/\/?tokens\/(0x[a-fA-F0-9]{40})(?:\/(\d+))?/);
+      if (tokensMatch) {
+        const contract = tokensMatch[1];
+        const tokenId = tokensMatch[2];
+        const pageUrl = tokenId ? `https://zora.co/tokens/${contract}/${tokenId}` : `https://zora.co/tokens/${contract}`;
+        return { pageUrl, contract, tokenId };
+      }
+
+      // collect patterns
+      const collectPattern1 = /\/?collect\/(?:([^/]+):)?(0x[a-fA-F0-9]{40})(?:\/(\d+))?/;
+      const collectPattern2 = /\/?collect\/(0x[a-fA-F0-9]{40})(?:\/(\d+))?/;
+      const collectMatch = decodedPath.match(collectPattern1) || decodedPath.match(collectPattern2);
+      if (collectMatch) {
+        let contract: string | undefined;
+        let tokenId: string | undefined;
+        if (collectMatch[2] && collectMatch[2].startsWith("0x")) {
+          contract = collectMatch[2];
+          tokenId = collectMatch[3];
+        } else if (collectMatch[1] && collectMatch[1].startsWith("0x")) {
+          contract = collectMatch[1];
+          tokenId = collectMatch[2];
+        }
+        // Normalize to coin/<contract>. If the collect path used a namespace (e.g. base:0x...)
+        const contractNormalized = contract ? (contract.includes(":") ? contract : contract) : undefined;
+        const pageUrl = contractNormalized
+          ? tokenId
+            ? `https://zora.co/coin/${contractNormalized}/${tokenId}`
+            : `https://zora.co/coin/${contractNormalized}`
+          : input;
+        return { pageUrl, contract: contractNormalized, tokenId };
+      }
+
+      return { pageUrl: input };
+    }
+
+    return null;
+  } catch (e) {
+    return null;
+  }
+};
+
+export default parseZoraUrl;

--- a/src/fidgets/zora/zoraEmbed.tsx
+++ b/src/fidgets/zora/zoraEmbed.tsx
@@ -24,7 +24,7 @@ export const ZoraProperties: FidgetProperties = {
     {
       fieldName: "text",
       default:
-        "https://zora.co/collect/zora:0x460779723619a8e25632bce2e74b6b9ce4915c7b/4",
+        "https://zora.co/coin/0x460779723619a8e25632bce2e74b6b9ce4915c7b/4",
       required: true,
       inputSelector: TextInput,
       group: "settings",


### PR DESCRIPTION

## Quick overview

We normalize Zora inputs into the canonical format `https://zora.co/coin/{contract}` and created an embed renderer for the timeline that shows a preview, title, and action button.

## What was done

- `src/fidgets/farcaster/components/Embeds/zoraUtils.ts`
  - `parseZoraUrl(input)` handles common variants (for example: `zora:`, `/collect/`, `/tokens/`) and returns the canonical URL, `contract`, and `tokenId` when available.
- `src/fidgets/farcaster/components/Embeds/ZoraEmbed.tsx`
  - Visualization component: a card with badge, title, and a “Trade” button that opens the canonical Zora page.
- `src/fidgets/zora/zoraEmbed.tsx`
  - Updated default example to `https://zora.co/coin/0x...`.

## Why this matters

- Prevents the feed from showing links in the `collect/...` format or with unnecessary prefixes like `zora:`.
- Makes direct actions easier (open token page / trade) directly from the feed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Zora embed support with styled cards showing preview images, titles, descriptions, site label, and Trade button.
  * Zora links are now auto-recognized and rendered as rich embeds with OpenGraph data and a loading skeleton.

* **Fallback**
  * Compact fallback card shows contract/token details and a View button when preview data is unavailable.

* **Other**
  * Improved Zora URL handling and updated default example URL for Zora properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->