### PR TITLE
Add Levr token embed fidget

### DIFF
--- a/src/common/data/services/fidgetOptionsService.ts
+++ b/src/common/data/services/fidgetOptionsService.ts
@@ -111,7 +111,9 @@ export class FidgetOptionsService {
           case 'swap':
           case 'market':
           case 'portfolio':
+          case 'Levr':
             primaryCategory = 'defi';
+            specificTags.push('token');
             break;
             
           // Content

--- a/src/fidgets/index.ts
+++ b/src/fidgets/index.ts
@@ -20,6 +20,7 @@ import VideoFidget from "./ui/Video";
 import marketData from "./token/marketData";
 import Portfolio from "./token/Portfolio";
 import ClankerManager from "./token/ClankerManager";
+import Levr from "./token/Levr";
 import Directory from "./token/Directory/Directory";
 import chat from "./ui/chat";
 import BuilderScore from "./farcaster/BuilderScore";
@@ -59,6 +60,7 @@ export const CompleteFidgets = {
   Market: marketData,
   Portfolio: Portfolio,
   ClankerManager: ClankerManager,
+  Levr: Levr,
   Directory: Directory,
   Chat: chat,
   Top8: Top8,

--- a/src/fidgets/token/Levr.tsx
+++ b/src/fidgets/token/Levr.tsx
@@ -25,7 +25,7 @@ const frameConfig: FidgetProperties = {
       displayName: "Contract Address",
       displayNameHint: "Enter the contract address for the Levr project",
       required: true,
-      default: "0xE3b708C2b23b168365eE43Ff70fbA80809dB2b07",
+      default: "",
       inputSelector: (props) => (
         <WithMargin>
           <TextInput {...props} />

--- a/src/fidgets/token/Levr.tsx
+++ b/src/fidgets/token/Levr.tsx
@@ -1,0 +1,93 @@
+import React, { useMemo } from "react";
+import TextInput from "@/common/components/molecules/TextInput";
+import {
+  FidgetArgs,
+  FidgetModule,
+  FidgetProperties,
+  type FidgetSettingsStyle,
+} from "@/common/fidgets";
+import { defaultStyleFields, WithMargin } from "@/fidgets/helpers";
+
+export type LevrSettings = {
+  contractAddress: string;
+} & FidgetSettingsStyle;
+
+const styleFields = defaultStyleFields.filter(
+  (field) => field.fieldName !== "background",
+);
+
+const frameConfig: FidgetProperties = {
+  fidgetName: "Levr",
+  icon: 0x1fa99, // 🪙
+  fields: [
+    {
+      fieldName: "contractAddress",
+      displayName: "Contract Address",
+      displayNameHint: "Enter the contract address for the Levr project",
+      required: true,
+      default: "0xE3b708C2b23b168365eE43Ff70fbA80809dB2b07",
+      inputSelector: (props) => (
+        <WithMargin>
+          <TextInput {...props} />
+        </WithMargin>
+      ),
+      group: "settings",
+    },
+    ...styleFields,
+  ],
+  size: {
+    minHeight: 6,
+    maxHeight: 36,
+    minWidth: 4,
+    maxWidth: 36,
+  },
+};
+
+const baseUrl = "https://www.levr.world/project/";
+
+const Levr: React.FC<FidgetArgs<LevrSettings>> = ({ settings }) => {
+  const { contractAddress, fidgetBorderColor, fidgetBorderWidth, fidgetShadow } =
+    settings;
+
+  const projectUrl = useMemo(() => {
+    const trimmedAddress = contractAddress?.trim();
+    if (!trimmedAddress) return null;
+    return `${baseUrl}${encodeURIComponent(trimmedAddress)}`;
+  }, [contractAddress]);
+
+  if (!projectUrl) {
+    return (
+      <div className="h-[calc(100dvh-220px)] md:h-full flex items-center justify-center">
+        <p className="text-muted-foreground text-center px-4">
+          Add a contract address to load the Levr project.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        overflow: "hidden",
+        width: "100%",
+        borderColor: fidgetBorderColor,
+        borderWidth: fidgetBorderWidth,
+        boxShadow: fidgetShadow,
+      }}
+      className="h-[calc(100dvh-220px)] md:h-full"
+    >
+      <iframe
+        src={projectUrl}
+        title="Levr Project"
+        className="size-full"
+        sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+        allow="clipboard-write; encrypted-media; fullscreen"
+      />
+    </div>
+  );
+};
+
+export default {
+  fidget: Levr,
+  properties: frameConfig,
+} as FidgetModule<FidgetArgs<LevrSettings>>;


### PR DESCRIPTION
## Summary
- add a Levr fidget that embeds levr.world projects by contract address with standard theme options
- register the fidget in the fidget registry and classify it under token/DeFi tooling for directory listings

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d24cacabc8325a43425eca942c74b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Levr fidget widget enabling users to display and interact with Levr project data. Users can input a contract address to view the corresponding Levr project in an embedded preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->