### PR TITLE
Add Empire Builder token fidget

### DIFF
--- a/src/common/data/services/fidgetOptionsService.ts
+++ b/src/common/data/services/fidgetOptionsService.ts
@@ -111,6 +111,7 @@ export class FidgetOptionsService {
           case 'swap':
           case 'market':
           case 'portfolio':
+          case 'EmpireBuilder':
             primaryCategory = 'defi';
             break;
             

--- a/src/fidgets/index.ts
+++ b/src/fidgets/index.ts
@@ -21,6 +21,7 @@ import marketData from "./token/marketData";
 import Portfolio from "./token/Portfolio";
 import ClankerManager from "./token/ClankerManager";
 import Directory from "./token/Directory/Directory";
+import EmpireBuilder from "./token/EmpireBuilder";
 import chat from "./ui/chat";
 import BuilderScore from "./farcaster/BuilderScore";
 import MobileStack from "./layout/tabFullScreen";
@@ -60,6 +61,7 @@ export const CompleteFidgets = {
   Portfolio: Portfolio,
   ClankerManager: ClankerManager,
   Directory: Directory,
+  EmpireBuilder: EmpireBuilder,
   Chat: chat,
   Top8: Top8,
   BuilderScore: BuilderScore,

--- a/src/fidgets/token/EmpireBuilder.tsx
+++ b/src/fidgets/token/EmpireBuilder.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import TextInput from "@/common/components/molecules/TextInput";
+import {
+  FidgetArgs,
+  FidgetModule,
+  FidgetProperties,
+  type FidgetSettingsStyle,
+} from "@/common/fidgets";
+import { defaultStyleFields, WithMargin } from "@/fidgets/helpers";
+import { GiCastle } from "react-icons/gi";
+
+export type EmpireBuilderSettings = {
+  contractAddress?: string;
+} & FidgetSettingsStyle;
+
+const styleFields = defaultStyleFields.filter(
+  (field) => field.fieldName !== "background",
+);
+
+const empireBuilderProperties: FidgetProperties = {
+  fidgetName: "Empire Builder",
+  icon: 0x1f3f0, // 🏰
+  mobileIcon: <GiCastle size={20} />,
+  fields: [
+    {
+      fieldName: "contractAddress",
+      displayName: "Contract address",
+      displayNameHint:
+        "Optional Ethereum contract address to load in Empire Builder",
+      default: "",
+      required: false,
+      inputSelector: (props) => (
+        <WithMargin>
+          <TextInput {...props} />
+        </WithMargin>
+      ),
+      group: "settings",
+    },
+    ...styleFields,
+  ],
+  size: {
+    minHeight: 6,
+    maxHeight: 36,
+    minWidth: 3,
+    maxWidth: 36,
+  },
+};
+
+const EmpireBuilder: React.FC<FidgetArgs<EmpireBuilderSettings>> = ({
+  settings,
+}) => {
+  const { contractAddress, fidgetBorderColor, fidgetBorderWidth, fidgetShadow } =
+    settings;
+  const normalizedAddress = contractAddress?.trim();
+  const url = normalizedAddress
+    ? `https://www.empirebuilder.world/empire/${normalizedAddress}`
+    : "https://www.empirebuilder.world";
+
+  return (
+    <div
+      style={{
+        overflow: "hidden",
+        width: "100%",
+        borderColor: fidgetBorderColor,
+        borderWidth: fidgetBorderWidth,
+        boxShadow: fidgetShadow,
+      }}
+      className="h-[calc(100dvh-220px)] md:h-full"
+    >
+      <iframe src={url} className="size-full" frameBorder="0" />
+    </div>
+  );
+};
+
+export default {
+  fidget: EmpireBuilder,
+  properties: empireBuilderProperties,
+} as FidgetModule<FidgetArgs<EmpireBuilderSettings>>;


### PR DESCRIPTION
## Summary
- allow the Empire Builder fidget to load the homepage when no contract address is provided
- keep the standard theme settings without background customization

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d27eb90708325a6ac4bde9b7582b4)