### PR TITLE
Restrict supported Node version to 22.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     ]
   },
   "engines": {
-    "node": "^22.12.0 || >=24.0.0"
+    "node": ">=22 <23"
   },
   "dependencies": {
     "@cloudflare/workers-types": "^4.20251109.0",


### PR DESCRIPTION
## Summary
- update the package engine requirement to target Node.js 22.x so installs ignore Node 24
- fixes the build error that all new PRs are getting

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69262afa48708325bb7e27aa310e2cad)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js engine compatibility requirements to version 22.x exclusively. This change narrows support from the previous dual-range configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->