### PR TITLE
Fix gallery fidget link handling

### DIFF
--- a/src/fidgets/ui/gallery.tsx
+++ b/src/fidgets/ui/gallery.tsx
@@ -30,7 +30,7 @@ import React, { CSSProperties, useEffect, useState } from "react";
 export type GalleryFidgetSettings = {
   imageUrl: string;
   uploadedImage: string;
-  RedirectionURL: string;
+  Link: string;
   Scale: number;
   selectMediaSource: MediaSource;
   nftAddress: string;
@@ -339,9 +339,11 @@ const Gallery: React.FC<FidgetArgs<GalleryFidgetSettings>> = ({ settings }) => {
     overflow: "hidden",
   } as CSSProperties;
 
-  return settings.RedirectionURL ? (
+  const redirectUrl = settings.Link?.trim();
+
+  return redirectUrl ? (
     <a
-      href={settings.RedirectionURL}
+      href={redirectUrl}
       target="_blank"
       rel="noopener noreferrer"
       className="absolute inset-0"


### PR DESCRIPTION
## Summary
- align the gallery/image fidget to read the Link setting that users configure
- trim the configured link before rendering so images become clickable again

## Testing
- yarn lint src/fidgets/ui/gallery.tsx *(fails: project has no `pages` or `app` directory for `next lint`)*
- yarn check-types --noEmit *(terminated manually due to long runtime)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693afc28d578832599c40369f585a58c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated Gallery widget's external link configuration system for enhanced consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->