### PR TITLE
Add API route for community config upsert

### DIFF
--- a/src/app/api/community-config/route.ts
+++ b/src/app/api/community-config/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from 'next/server';
+import createSupabaseServerClient from '@/common/data/database/supabase/clients/server';
+
+interface IncomingCommunityConfig {
+  community_id?: string;
+  admin_address?: string;
+  domain?: string;
+  brand_config?: unknown;
+  assets_config?: unknown;
+  community_config?: unknown;
+  fidgets_config?: unknown;
+  navigation_config?: unknown;
+  ui_config?: unknown;
+  is_published?: boolean;
+}
+
+export async function POST(request: NextRequest): Promise<Response> {
+  try {
+    const body = await request.json();
+    const incomingConfig: IncomingCommunityConfig | undefined = body?.community_config;
+
+    if (!incomingConfig || typeof incomingConfig !== 'object') {
+      return NextResponse.json(
+        { success: false, error: 'Missing community_config payload' },
+        { status: 400 }
+      );
+    }
+
+    const {
+      community_id: communityId,
+      admin_address: adminAddress,
+      domain,
+      brand_config: brandConfig,
+      assets_config: assetsConfig,
+      community_config: communityDetails,
+      fidgets_config: fidgetsConfig,
+      navigation_config: navigationConfig,
+      ui_config: uiConfig,
+      is_published: isPublished,
+    } = incomingConfig;
+
+    if (!communityId) {
+      return NextResponse.json(
+        { success: false, error: 'community_id is required' },
+        { status: 400 }
+      );
+    }
+
+    if (!brandConfig || !assetsConfig || !communityDetails || !fidgetsConfig) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'brand_config, assets_config, community_config, and fidgets_config are required',
+        },
+        { status: 400 }
+      );
+    }
+
+    const supabase = createSupabaseServerClient();
+
+    const normalizedCommunityDetails =
+      communityDetails && typeof communityDetails === 'object'
+        ? {
+            ...(communityDetails as Record<string, unknown>),
+            ...(adminAddress ? { admin_address: adminAddress } : {}),
+            ...(domain ? { domain } : {}),
+          }
+        : communityDetails;
+
+    const { data, error } = await supabase
+      .from('community_configs')
+      .upsert(
+        {
+          community_id: communityId,
+          brand_config: brandConfig,
+          assets_config: assetsConfig,
+          community_config: normalizedCommunityDetails,
+          fidgets_config: fidgetsConfig,
+          navigation_config: navigationConfig ?? null,
+          ui_config: uiConfig ?? null,
+          is_published: isPublished ?? true,
+        },
+        { onConflict: 'community_id' }
+      )
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Error upserting community config:', error);
+      return NextResponse.json(
+        { success: false, error: 'Failed to save community config' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    console.error('community-config POST error:', error);
+    return NextResponse.json(
+      { success: false, error: 'Invalid JSON or server error' },
+      { status: 400 }
+    );
+  }
+}

--- a/src/config/loaders/registry.ts
+++ b/src/config/loaders/registry.ts
@@ -1,3 +1,6 @@
+import { createSupabaseServerClient } from '@/common/data/database/supabase/clients/server';
+import { Database } from '@/supabase/database';
+
 /**
  * Special domain mappings
  * 
@@ -13,6 +16,38 @@ const DOMAIN_TO_COMMUNITY_MAP: Record<string, string> = {
   'staging.nounspace.com': 'nouns',
   'nounspace.vercel.app': 'nouns',
 };
+
+type CommunityConfigRow = Database['public']['Tables']['community_configs']['Row'];
+
+/**
+ * Cache entry for community configuration lookups.
+ *
+ * Keeps a short-lived in-memory cache to reduce Supabase round-trips when the
+ * same domain is requested repeatedly (e.g., during navigation or asset loads).
+ */
+type CommunityConfigCacheEntry = {
+  expiresAt: number;
+  value: CommunityConfigRow | null;
+};
+
+const COMMUNITY_CONFIG_CACHE = new Map<string, CommunityConfigCacheEntry>();
+const COMMUNITY_CONFIG_CACHE_TTL_MS = 60_000;
+
+/**
+ * Normalize an incoming domain/host value for consistent resolution.
+ *
+ * - Lowercases the domain
+ * - Strips any port numbers
+ * - Removes a leading `www.` prefix when present
+ */
+export function normalizeDomain(domain: string): string {
+  if (!domain) return '';
+
+  const host = domain.split(':')[0]?.trim().toLowerCase() ?? '';
+  if (!host) return '';
+
+  return host.startsWith('www.') ? host.slice(4) : host;
+}
 
 /**
  * Resolve community ID from domain
@@ -30,23 +65,24 @@ const DOMAIN_TO_COMMUNITY_MAP: Record<string, string> = {
 export function resolveCommunityFromDomain(
   domain: string
 ): string | null {
-  if (!domain) return null;
+  const normalizedDomain = normalizeDomain(domain);
+  if (!normalizedDomain) return null;
   
   // Check special domain mappings first (highest priority)
-  if (domain in DOMAIN_TO_COMMUNITY_MAP) {
-    return DOMAIN_TO_COMMUNITY_MAP[domain];
+  if (normalizedDomain in DOMAIN_TO_COMMUNITY_MAP) {
+    return DOMAIN_TO_COMMUNITY_MAP[normalizedDomain];
   }
   
   // Handle Vercel preview deployments (e.g., nounspace.vercel.app, branch-nounspace.vercel.app)
   // All Vercel preview deployments should point to nouns community
-  if (domain.endsWith('.vercel.app') && domain.includes('nounspace')) {
+  if (normalizedDomain.endsWith('.vercel.app') && normalizedDomain.includes('nounspace')) {
     return 'nouns';
   }
   
   // Support localhost subdomains for local testing
   // e.g., example.localhost:3000 -> example
-  if (domain.includes('localhost')) {
-    const parts = domain.split('.');
+  if (normalizedDomain.includes('localhost')) {
+    const parts = normalizedDomain.split('.');
     if (parts.length > 1 && parts[0] !== 'localhost') {
       // Has subdomain before localhost
       return parts[0];
@@ -57,8 +93,8 @@ export function resolveCommunityFromDomain(
   
   // Production domain: extract subdomain or use domain as community ID
   // Example: subdomain.nounspace.com -> subdomain
-  if (domain.includes('.')) {
-    const parts = domain.split('.');
+  if (normalizedDomain.includes('.')) {
+    const parts = normalizedDomain.split('.');
     if (parts.length > 2) {
       // Has subdomain (e.g., example.nounspace.com)
       return parts[0];
@@ -68,7 +104,95 @@ export function resolveCommunityFromDomain(
   }
   
   // Single word domain - use as community ID
-  return domain;
+  return normalizedDomain;
 }
 
+/**
+ * Attempt to read a cached community config entry if it has not expired.
+ */
+function readCommunityConfigCache(communityId: string): CommunityConfigRow | null | undefined {
+  const entry = COMMUNITY_CONFIG_CACHE.get(communityId);
+  if (!entry) return undefined;
 
+  if (entry.expiresAt > Date.now()) {
+    return entry.value;
+  }
+
+  COMMUNITY_CONFIG_CACHE.delete(communityId);
+  return undefined;
+}
+
+/**
+ * Store a community config value in the cache with a short TTL.
+ */
+function writeCommunityConfigCache(communityId: string, value: CommunityConfigRow | null) {
+  COMMUNITY_CONFIG_CACHE.set(communityId, {
+    expiresAt: Date.now() + COMMUNITY_CONFIG_CACHE_TTL_MS,
+    value,
+  });
+}
+
+/**
+ * Fetch the community configuration row for a given domain.
+ *
+ * Resolution priority:
+ * 1) Normalize the domain (lowercase, strip port, drop leading `www.`)
+ * 2) Apply DOMAIN_TO_COMMUNITY_MAP overrides
+ * 3) Fall back to using the normalized host as the community_id (domain is stored in community_id)
+ *
+ * A short-lived in-memory cache is used to avoid repeated Supabase lookups for the same
+ * community during navigation bursts.
+ */
+export async function getCommunityConfigForDomain(domain: string): Promise<CommunityConfigRow | null> {
+  const normalizedDomain = normalizeDomain(domain);
+  if (!normalizedDomain) return null;
+
+  const communityId = resolveCommunityFromDomain(normalizedDomain);
+  if (!communityId) return null;
+
+  const cached = readCommunityConfigCache(communityId);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const supabase = createSupabaseServerClient();
+  const { data, error } = await supabase
+    .from('community_configs')
+    .select('*')
+    .eq('community_id', communityId)
+    .single();
+
+  if (error) {
+    console.error('Failed to fetch community config', { communityId, error });
+    writeCommunityConfigCache(communityId, null);
+    return null;
+  }
+
+  writeCommunityConfigCache(communityId, data ?? null);
+  return data ?? null;
+}
+
+/**
+ * Resolve and return the community ID and configuration for a domain.
+ *
+ * If no configuration is found, returns null and logs a warning for visibility.
+ */
+export async function resolveCommunityConfig(
+  domain: string
+): Promise<{ communityId: string; config: CommunityConfigRow } | null> {
+  const normalizedDomain = normalizeDomain(domain);
+  const communityId = normalizedDomain ? resolveCommunityFromDomain(normalizedDomain) : null;
+
+  if (!communityId) {
+    return null;
+  }
+
+  const config = await getCommunityConfigForDomain(normalizedDomain);
+
+  if (!config) {
+    console.warn('Community config not found for domain', { domain: normalizedDomain, communityId });
+    return null;
+  }
+
+  return { communityId, config };
+}

--- a/src/supabase/database.d.ts
+++ b/src/supabase/database.d.ts
@@ -183,6 +183,45 @@ export type Database = {
         }
         Relationships: []
       }
+      community_configs: {
+        Row: {
+          assets_config: Json
+          brand_config: Json
+          community_config: Json
+          community_id: string
+          fidgets_config: Json
+          id: string
+          is_published: boolean | null
+          navigation_config: Json | null
+          ui_config: Json | null
+          updated_at: string | null
+        }
+        Insert: {
+          assets_config: Json
+          brand_config: Json
+          community_config: Json
+          community_id: string
+          fidgets_config: Json
+          id?: string
+          is_published?: boolean | null
+          navigation_config?: Json | null
+          ui_config?: Json | null
+          updated_at?: string | null
+        }
+        Update: {
+          assets_config?: Json
+          brand_config?: Json
+          community_config?: Json
+          community_id?: string
+          fidgets_config?: Json
+          id?: string
+          is_published?: boolean | null
+          navigation_config?: Json | null
+          ui_config?: Json | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
       fidRegistrations: {
         Row: {
           created: string


### PR DESCRIPTION
## Summary
- add a public POST `/api/community-config` route to parse incoming community configuration payloads and upsert them into the `community_configs` table
- normalize optional admin address and domain fields into the stored `community_config` JSON when present
- extend Supabase database typings to cover the `community_configs` table

## Testing
- yarn lint *(fails: package missing from lockfile in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69447251307483259f886eefb778bf43)