### PR TITLE
refactor(space): unify tab registration and commit flow

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -187,7 +187,7 @@ export default function Space({
         },
         fidgetInstanceDatums: cleanedFidgetInstanceDatums,
         timestamp: new Date().toISOString(),
-      }).then(commitConfig);
+      });
     }
 
     cleanupHasRun.current = true;

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -104,15 +104,14 @@ function TabBar({
           switchTabTo(finalTabName, false);
         }
         
-        // Commit the order (createTab already updated local state)
-        commitTabOrder();
+        // Tab creation is staged - commit via commitAllSpaceChanges
       } catch (error) {
         console.error("Error creating tab:", error);
         toast.error("Failed to create tab. Please try again.");
         // TODO: Rollback optimistic changes if needed
       }
     }, 300),
-    [tabList, createTab, commitTabOrder, switchTabTo]
+    [tabList, createTab, switchTabTo]
   );
 
   const debouncedDeleteTab = React.useCallback(
@@ -177,16 +176,15 @@ function TabBar({
         // Update current tab name in store and URL
         switchTabTo(uniqueName);
         
-        // Wait for rename to complete, then commit
+        // Wait for rename to complete
         await renamePromise;
-        commitTab(uniqueName);
-        commitTabOrder();
+        // Rename is staged - commit via commitAllSpaceChanges
         
       } catch (error) {
         console.error("Error in handleRenameTab:", error);
       }
     }, 300),
-    [renameTab, switchTabTo, commitTab, commitTabOrder, tabList]
+    [renameTab, switchTabTo, tabList]
   );
 
   function generateNewTabName(): string {
@@ -236,9 +234,9 @@ function TabBar({
   const debouncedReorder = React.useCallback(
     debounce((newOrder) => {
       updateTabOrder(newOrder);
-      commitTabOrder();
+      // Order update is staged - commit via commitAllSpaceChanges
     }, 300),
-    [updateTabOrder, commitTabOrder]
+    [updateTabOrder]
   );
 
   const isLoggedIn = getIsLoggedIn();

--- a/src/config/loaders/registry.ts
+++ b/src/config/loaders/registry.ts
@@ -39,7 +39,8 @@ export function resolveCommunityFromDomain(
   
   // Handle Vercel preview deployments (e.g., nounspace.vercel.app, branch-nounspace.vercel.app)
   // All Vercel preview deployments should point to nouns community
-  if (domain.endsWith('.vercel.app') && domain.includes('nounspace')) {
+  // Match any .vercel.app domain (preview deployments have random branch names)
+  if (domain.endsWith('.vercel.app')) {
     return 'nouns';
   }
   

--- a/src/pages/api/space/registry/[spaceId]/tabs/[tabId].ts
+++ b/src/pages/api/space/registry/[spaceId]/tabs/[tabId].ts
@@ -106,12 +106,9 @@ async function updateSpace(
       // Check if it's a StorageApiError (has HTTP status) or base StorageError
       const isApiError = error instanceof StorageApiError;
       const status = isApiError ? error.status : undefined;
-      // Also check statusCode as fallback (Supabase may return string status codes)
-      const statusCode = (error as any).statusCode;
       
-      // Check for 404 status (file not found) - Supabase may return string or number status codes
-      const is404 = status === 404 || status === '404' || statusCode === 404 || statusCode === '404';
-      if (is404) {
+      // Check for 404 status (file not found) - StorageApiError.status is a number
+      if (status === 404) {
         // Expected case: File doesn't exist - this is fine for new tabs renamed before commit
         // We'll create it at the new location via upload with upsert
         console.log(`[Expected] File ${tabName} not found, creating at ${req.fileName} instead`);
@@ -119,7 +116,6 @@ async function updateSpace(
         // Unexpected error - fail and log for monitoring
         console.error(`[Unexpected] Move failed for ${tabName} → ${req.fileName}:`, {
           status,
-          statusCode,
           message: error.message,
           errorType: isApiError ? 'StorageApiError' : 'StorageError',
           error: error,

--- a/src/pages/api/space/registry/[spaceId]/tabs/[tabId].ts
+++ b/src/pages/api/space/registry/[spaceId]/tabs/[tabId].ts
@@ -109,8 +109,9 @@ async function updateSpace(
       // Also check statusCode as fallback (Supabase may return string status codes)
       const statusCode = (error as any).statusCode;
       
-      // Check for 404 status (file not found) - Supabase returns string status codes like '404'
-      if (status === '404' || statusCode === '404') {
+      // Check for 404 status (file not found) - Supabase may return string or number status codes
+      const is404 = status === 404 || status === '404' || statusCode === 404 || statusCode === '404';
+      if (is404) {
         // Expected case: File doesn't exist - this is fine for new tabs renamed before commit
         // We'll create it at the new location via upload with upsert
         console.log(`[Expected] File ${tabName} not found, creating at ${req.fileName} instead`);


### PR DESCRIPTION
- Enhance commitSpaceTabToDatabase to handle new tabs renamed before commit
- Remove registerSpaceTab (commitSpaceTabToDatabase now handles both)
- Update API endpoint to use upload() with upsert:true for create/update
- Improve error handling with proper types and statusCode checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Track deleted tabs locally and add a single "commit all" action to batch creates, renames, deletions, and order updates.

* **Changes**
  * Tab create/rename/reorder and cleanup now stage changes locally and defer persistence to the batched commit for consistency.
  * Vercel preview domains now map to the nouns community by default.

* **Bug Fixes**
  * More robust handling of remote file moves/uploads and clearer error handling for rename/upload edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->