### PR TITLE
Handle unknown domains by falling back to nounspace config

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -246,7 +246,7 @@ async function seedCommunityConfigs(assetsUrls: Record<string, string>) {
   const { error: nounsError } = await supabase
     .from('community_configs')
     .upsert({
-      community_id: 'nouns',
+      community_id: 'nounspace.com',
       is_published: true,
       brand_config: {
         displayName: 'Nouns',
@@ -464,7 +464,7 @@ async function seedCommunityConfigs(assetsUrls: Record<string, string>) {
 
   // Clanker config
   const { error: clankerError } = await supabase.from('community_configs').upsert({
-    community_id: 'clanker',
+    community_id: 'clanker.space',
     is_published: true,
     brand_config: {
       displayName: 'Clanker',
@@ -780,7 +780,7 @@ async function checkSeeding(): Promise<boolean> {
   // Test the RPC function
   console.log('\n🧪 Testing get_active_community_config function...');
   const { data: testConfig, error: testError } = await supabase
-    .rpc('get_active_community_config', { p_community_id: 'nouns' })
+    .rpc('get_active_community_config', { p_community_id: 'nounspace.com' })
     .single();
 
   if (testError) {

--- a/src/config/loaders/index.ts
+++ b/src/config/loaders/index.ts
@@ -16,5 +16,4 @@
 export * from './types';
 export * from './registry';
 export * from './runtimeLoader';
-export { resolveCommunityId, getDomainFromContext } from './utils';
-
+export { resolveCommunityId, getDomainFromContext, getCommunityIdFromHeaders } from './utils';

--- a/src/config/loaders/registry.ts
+++ b/src/config/loaders/registry.ts
@@ -9,7 +9,6 @@ import { Database } from '@/supabase/database';
  * 
  * Examples:
  * - staging.nounspace.com -> nounspace.com
- * - staging.localhost -> nouns (for local testing)
  */
 const DOMAIN_TO_COMMUNITY_MAP: Record<string, string> = {
   'staging.nounspace.com': 'nounspace.com',

--- a/src/config/loaders/registry.ts
+++ b/src/config/loaders/registry.ts
@@ -8,14 +8,14 @@ import { Database } from '@/supabase/database';
  * Useful for staging environments, special domains, etc.
  * 
  * Examples:
- * - staging.nounspace.com -> nouns
+ * - staging.nounspace.com -> nounspace.com
  * - staging.localhost -> nouns (for local testing)
  */
 const DOMAIN_TO_COMMUNITY_MAP: Record<string, string> = {
-  'staging.nounspace.com': 'nouns',
+  'staging.nounspace.com': 'nounspace.com',
 };
 
-const DEFAULT_COMMUNITY_ID = 'nounspace.com';
+export const DEFAULT_COMMUNITY_ID = 'nounspace.com';
 
 type CommunityConfigRow = Database['public']['Tables']['community_configs']['Row'];
 
@@ -60,14 +60,6 @@ function getCommunityIdCandidates(domain: string): string[] {
   if (normalizedDomain.includes('localhost')) {
     const parts = normalizedDomain.split('.');
     if (parts.length > 1 && parts[0] !== 'localhost') {
-      addCandidate(parts[0]);
-    }
-  }
-
-  // Fallback: derive community from the leading subdomain (e.g., example.nounspace.com -> example)
-  if (normalizedDomain.includes('.')) {
-    const parts = normalizedDomain.split('.');
-    if (parts[0]) {
       addCandidate(parts[0]);
     }
   }
@@ -146,8 +138,7 @@ function writeCommunityConfigCache(communityId: string, value: CommunityConfigRo
  * 1) Normalize the domain (lowercase, strip port, drop leading `www.`)
  * 2) Apply DOMAIN_TO_COMMUNITY_MAP overrides
  * 3) Try exact domain match in community_id (e.g., example.blank.space -> community_id=example.blank.space)
- * 4) Fall back to using the leading subdomain as community_id (e.g., example.blank.space -> example)
- * 5) Use the default nounspace community when no explicit match is found
+ * 4) Use the default nounspace community when no explicit match is found
  *
  * A short-lived in-memory cache is used to avoid repeated Supabase lookups for the same
  * community during navigation bursts.

--- a/src/config/loaders/registry.ts
+++ b/src/config/loaders/registry.ts
@@ -9,12 +9,10 @@ import { Database } from '@/supabase/database';
  * 
  * Examples:
  * - staging.nounspace.com -> nouns
- * - nounspace.vercel.app -> nouns (Vercel preview deployments)
  * - staging.localhost -> nouns (for local testing)
  */
 const DOMAIN_TO_COMMUNITY_MAP: Record<string, string> = {
   'staging.nounspace.com': 'nouns',
-  'nounspace.vercel.app': 'nouns',
 };
 
 const DEFAULT_COMMUNITY_ID = 'nounspace.com';
@@ -57,11 +55,6 @@ function getCommunityIdCandidates(domain: string): string[] {
 
   // Highest priority: exact domain match
   addCandidate(normalizedDomain);
-
-  // Handle Vercel preview deployments (e.g., nounspace.vercel.app, branch-nounspace.vercel.app)
-  if (normalizedDomain.endsWith('.vercel.app') && normalizedDomain.includes('nounspace')) {
-    addCandidate('nouns');
-  }
 
   // Support localhost subdomains for local testing (e.g., example.localhost)
   if (normalizedDomain.includes('localhost')) {

--- a/src/config/loaders/utils.ts
+++ b/src/config/loaders/utils.ts
@@ -37,6 +37,27 @@ export function resolveCommunityId(context: ConfigLoadContext): string | undefin
 }
 
 /**
+ * Reads the community ID that middleware detected (when available).
+ *
+ * Middleware sets the `x-community-id` header after resolving the community
+ * config from the domain. When present, this header should be treated as the
+ * authoritative community ID to avoid re-resolving and to reuse middleware
+ * fallbacks (e.g., defaulting unknown domains to nounspace.com).
+ */
+export async function getCommunityIdFromHeaders(): Promise<string | undefined> {
+  try {
+    const { headers } = await import('next/headers');
+    const headersList = await headers();
+
+    const communityId = headersList.get('x-community-id');
+    return communityId ?? undefined;
+  } catch (error) {
+    // Not in a request context (static generation, etc.)
+    return undefined;
+  }
+}
+
+/**
  * Get domain from middleware-set headers (SERVER-ONLY)
  * 
  * Server-side: Reads x-detected-domain header set by middleware, or falls back

--- a/src/config/loaders/utils.ts
+++ b/src/config/loaders/utils.ts
@@ -1,5 +1,5 @@
 import { ConfigLoadContext } from './types';
-import { resolveCommunityFromDomain } from './registry';
+import { DEFAULT_COMMUNITY_ID, resolveCommunityFromDomain } from './registry';
 
 /**
  * Resolve community ID from context
@@ -8,10 +8,10 @@ import { resolveCommunityFromDomain } from './registry';
  * 1. Explicit context.communityId
  * 2. Development override (NEXT_PUBLIC_TEST_COMMUNITY) - for local testing only
  * 3. Domain resolution (production or localhost subdomains)
- * 4. Build-time fallback (NEXT_PUBLIC_TEST_COMMUNITY or 'nouns') - for static generation
+ * 4. Build-time fallback (NEXT_PUBLIC_TEST_COMMUNITY or default community) - for static generation
  * 
  * Note: During build time (static generation), there's no request context, so we use
- * NEXT_PUBLIC_TEST_COMMUNITY if set, otherwise default to 'nouns' as a fallback.
+ * NEXT_PUBLIC_TEST_COMMUNITY if set, otherwise default to the nounspace community as a fallback.
  */
 export function resolveCommunityId(context: ConfigLoadContext): string | undefined {
   let communityId = context.communityId;
@@ -28,9 +28,9 @@ export function resolveCommunityId(context: ConfigLoadContext): string | undefin
   }
 
   // Build-time fallback: when there's no request context (static generation)
-  // Use NEXT_PUBLIC_TEST_COMMUNITY if set, otherwise default to 'nouns'
+  // Use NEXT_PUBLIC_TEST_COMMUNITY if set, otherwise default to nounspace.com
   if (!communityId) {
-    communityId = process.env.NEXT_PUBLIC_TEST_COMMUNITY || 'nouns';
+    communityId = process.env.NEXT_PUBLIC_TEST_COMMUNITY || DEFAULT_COMMUNITY_ID;
   }
 
   return communityId;
@@ -76,4 +76,3 @@ export async function getDomainFromContext(): Promise<string | undefined> {
   
   return undefined;
 }
-


### PR DESCRIPTION
## Summary
- add a default nounspace community id fallback when resolving community configs
- include the default nounspace candidate so unexpected domains map to the default config instead of failing
- update domain resolution docs to reflect the new fallback behavior
- update seed script to generate nouns and clanker community_configs with nounspace.com and clanker.space community_id
- removed the vercel-specific fallback to nounspace since the catch-all fallback handles that now

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945d3d405708325919cfc37b7870452)