### PR TITLE
fix: improve embed previews and custom embeds

### DIFF
--- a/src/app/api/github/route.ts
+++ b/src/app/api/github/route.ts
@@ -1,0 +1,244 @@
+import { NextRequest, NextResponse } from "next/server";
+
+type ParsedGitHubUrl = {
+  owner: string;
+  repo: string;
+  type: "repo" | "issue" | "pull" | "user";
+  number?: number;
+};
+
+const cacheHeaders = {
+  "Cache-Control": "public, s-maxage=300, stale-while-revalidate=600",
+};
+
+const getGitHubHeaders = () => {
+  const headers: Record<string, string> = {
+    "User-Agent": "nounspace",
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+
+  const token = process.env.GITHUB_TOKEN;
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  return headers;
+};
+
+const parseGitHubUrl = (rawUrl: string): ParsedGitHubUrl | null => {
+  try {
+    const parsed = new URL(rawUrl);
+    if (parsed.hostname !== "github.com" && parsed.hostname !== "www.github.com") {
+      return null;
+    }
+
+    const parts = parsed.pathname.split("/").filter(Boolean);
+    if (parts.length === 0) return null;
+
+    const blockedUserSlugs = new Set([
+      "explore",
+      "topics",
+      "settings",
+      "marketplace",
+      "about",
+      "pricing",
+      "features",
+      "collections",
+      "sponsors",
+      "orgs",
+      "users",
+    ]);
+
+    if (parts.length === 1) {
+      const owner = parts[0];
+      if (!owner || blockedUserSlugs.has(owner)) return null;
+      return { owner, repo: "", type: "user" };
+    }
+
+    if (parts[0] === "orgs" || parts[0] === "users") {
+      const owner = parts[1];
+      if (!owner) return null;
+      return { owner, repo: "", type: "user" };
+    }
+
+    const owner = parts[0];
+    const repo = parts[1]?.replace(/\.git$/, "");
+    if (!owner || !repo) return null;
+
+    const section = parts[2];
+    const number = parts[3] ? Number(parts[3]) : undefined;
+
+    if ((section === "issues" || section === "pull" || section === "pulls") && number && Number.isFinite(number)) {
+      return {
+        owner,
+        repo,
+        type: section === "issues" ? "issue" : "pull",
+        number,
+      };
+    }
+
+    return { owner, repo, type: "repo" };
+  } catch {
+    return null;
+  }
+};
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const url = searchParams.get("url");
+
+  if (!url) {
+    return NextResponse.json({ error: "URL parameter is required" }, { status: 400 });
+  }
+
+  const parsed = parseGitHubUrl(url);
+  if (!parsed) {
+    return NextResponse.json({ error: "Unsupported GitHub URL" }, { status: 400 });
+  }
+
+  const headers = getGitHubHeaders();
+
+  try {
+    if (parsed.type === "user") {
+      const userResponse = await fetch(
+        `https://api.github.com/users/${parsed.owner}`,
+        { headers, next: { revalidate: 300 } }
+      );
+
+      if (!userResponse.ok) {
+        return NextResponse.json({ error: "Failed to fetch user" }, { status: userResponse.status, headers: cacheHeaders });
+      }
+
+      const user = await userResponse.json();
+
+      return NextResponse.json(
+        {
+          type: "user",
+          url: user.html_url,
+          user: {
+            login: user.login,
+            name: user.name,
+            bio: user.bio,
+            avatarUrl: user.avatar_url,
+            followers: user.followers,
+            following: user.following,
+            publicRepos: user.public_repos,
+            company: user.company,
+            location: user.location,
+          },
+        },
+        { headers: cacheHeaders }
+      );
+    }
+
+    if (parsed.type === "repo") {
+      const repoResponse = await fetch(
+        `https://api.github.com/repos/${parsed.owner}/${parsed.repo}`,
+        { headers, next: { revalidate: 300 } }
+      );
+
+      if (!repoResponse.ok) {
+        return NextResponse.json({ error: "Failed to fetch repo" }, { status: repoResponse.status, headers: cacheHeaders });
+      }
+
+      const repo = await repoResponse.json();
+
+      return NextResponse.json(
+        {
+          type: "repo",
+          url: repo.html_url,
+          repo: {
+            owner: repo.owner?.login,
+            name: repo.name,
+            fullName: repo.full_name,
+            url: repo.html_url,
+            avatarUrl: repo.owner?.avatar_url,
+          },
+          description: repo.description,
+          language: repo.language,
+          topics: Array.isArray(repo.topics) ? repo.topics : [],
+          license: repo.license?.spdx_id ?? null,
+          isFork: repo.fork,
+          isPrivate: repo.private,
+          isArchived: repo.archived,
+          stats: {
+            stars: repo.stargazers_count,
+            forks: repo.forks_count,
+            issues: repo.open_issues_count,
+            watchers: repo.watchers_count,
+          },
+          updatedAt: repo.updated_at,
+        },
+        { headers: cacheHeaders }
+      );
+    }
+
+    const issueResponse = await fetch(
+      `https://api.github.com/repos/${parsed.owner}/${parsed.repo}/issues/${parsed.number}`,
+      { headers, next: { revalidate: 300 } }
+    );
+
+    if (!issueResponse.ok) {
+      return NextResponse.json({ error: "Failed to fetch issue" }, { status: issueResponse.status, headers: cacheHeaders });
+    }
+
+    const issue = await issueResponse.json();
+    const isPullRequest = !!issue.pull_request || parsed.type === "pull";
+    let merged = false;
+    let draft = false;
+
+    if (isPullRequest) {
+      const prResponse = await fetch(
+        `https://api.github.com/repos/${parsed.owner}/${parsed.repo}/pulls/${parsed.number}`,
+        { headers, next: { revalidate: 300 } }
+      );
+      if (prResponse.ok) {
+        const pr = await prResponse.json();
+        merged = !!pr.merged_at;
+        draft = !!pr.draft;
+      }
+    }
+
+    return NextResponse.json(
+      {
+        type: isPullRequest ? "pull" : "issue",
+        url: issue.html_url,
+        repo: {
+          owner: parsed.owner,
+          name: parsed.repo,
+          fullName: `${parsed.owner}/${parsed.repo}`,
+          url: `https://github.com/${parsed.owner}/${parsed.repo}`,
+          avatarUrl: issue.repository?.owner?.avatar_url,
+        },
+        issue: {
+          number: issue.number,
+          title: issue.title,
+          state: issue.state,
+          comments: issue.comments,
+          updatedAt: issue.updated_at,
+          author: issue.user
+            ? {
+                login: issue.user.login,
+                avatarUrl: issue.user.avatar_url,
+                url: issue.user.html_url,
+              }
+            : null,
+          labels: Array.isArray(issue.labels)
+            ? issue.labels
+                .map((label: { name?: string; color?: string }) => ({
+                  name: label.name || "",
+                  color: label.color || "6b7280",
+                }))
+                .filter((label: { name: string }) => !!label.name)
+            : [],
+          isMerged: merged,
+          isDraft: draft,
+        },
+      },
+      { headers: cacheHeaders }
+    );
+  } catch (error) {
+    return NextResponse.json({ error: "Failed to fetch GitHub data" }, { status: 500, headers: cacheHeaders });
+  }
+}

--- a/src/app/api/nounscolor/route.ts
+++ b/src/app/api/nounscolor/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const SOURCE_URL = "https://nounscolor.xctx.io/noun_colors_extracted.json";
+const CACHE_HEADERS = {
+  "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=7200",
+};
+
+type NounColors = Record<string, Record<string, number>>;
+
+const MAX_RGB_DISTANCE = Math.sqrt(255 ** 2 * 3);
+
+const normalizeHex = (value: string | null): string | null => {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const raw = trimmed.startsWith("#") ? trimmed.slice(1) : trimmed;
+  if (raw.length === 3 && /^[0-9a-fA-F]{3}$/.test(raw)) {
+    return `#${raw.split("").map((ch) => ch + ch).join("").toLowerCase()}`;
+  }
+  if (/^[0-9a-fA-F]{6}$/.test(raw)) {
+    return `#${raw.toLowerCase()}`;
+  }
+  return null;
+};
+
+const parseHexColor = (hex: string): [number, number, number] | null => {
+  const cleaned = hex.replace("#", "");
+  if (cleaned.length !== 6) return null;
+  const r = parseInt(cleaned.slice(0, 2), 16);
+  const g = parseInt(cleaned.slice(2, 4), 16);
+  const b = parseInt(cleaned.slice(4, 6), 16);
+  if ([r, g, b].some((value) => Number.isNaN(value))) return null;
+  return [r, g, b];
+};
+
+const colorDistance = (a: [number, number, number], b: [number, number, number]) => {
+  const dr = a[0] - b[0];
+  const dg = a[1] - b[1];
+  const db = a[2] - b[2];
+  return Math.sqrt(dr * dr + dg * dg + db * db);
+};
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const limit = Number(searchParams.get("limit") ?? "10");
+  const safeLimit = Number.isFinite(limit) && limit > 0 ? Math.min(limit, 20) : 10;
+  const nounLimit = Number(searchParams.get("nounLimit") ?? "6");
+  const safeNounLimit = Number.isFinite(nounLimit) && nounLimit > 0 ? Math.min(nounLimit, 12) : 6;
+  const matchColor = normalizeHex(searchParams.get("color"));
+  const tolerance = Number(searchParams.get("tolerance") ?? "20");
+  const safeTolerance = Number.isFinite(tolerance) ? Math.min(Math.max(tolerance, 0), 100) : 20;
+  const targetRgb = matchColor ? parseHexColor(matchColor) : null;
+  const distanceThreshold = targetRgb ? (safeTolerance / 100) * MAX_RGB_DISTANCE : null;
+
+  try {
+    const response = await fetch(SOURCE_URL, {
+      headers: { "User-Agent": "nounspace" },
+      next: { revalidate: 3600 },
+    });
+
+    if (!response.ok) {
+      return NextResponse.json({ error: "Failed to fetch Nouns color data" }, { status: response.status });
+    }
+
+    const nounData = (await response.json()) as NounColors;
+    const entries = Object.entries(nounData);
+    const colorCounts = new Map<string, number>();
+    const nounTotals: Array<[string, number]> = [];
+    const nounMatches: Array<[string, number]> = [];
+    const rgbCache = new Map<string, [number, number, number]>();
+
+    for (const [nounId, colors] of entries) {
+      let nounTotal = 0;
+      let matchedTotal = 0;
+      for (const [hex, count] of Object.entries(colors)) {
+        const normalized = hex.startsWith("#") ? hex.toLowerCase() : `#${hex.toLowerCase()}`;
+        const numericCount = Number(count);
+        const safeCount = Number.isFinite(numericCount) ? numericCount : 0;
+        nounTotal += safeCount;
+        colorCounts.set(normalized, (colorCounts.get(normalized) ?? 0) + safeCount);
+        if (targetRgb && distanceThreshold !== null && safeCount > 0) {
+          let rgb = rgbCache.get(normalized);
+          if (!rgb) {
+            const parsed = parseHexColor(normalized);
+            if (parsed) {
+              rgbCache.set(normalized, parsed);
+              rgb = parsed;
+            }
+          }
+          if (rgb && colorDistance(rgb, targetRgb) <= distanceThreshold) {
+            matchedTotal += safeCount;
+          }
+        }
+      }
+      nounTotals.push([nounId, nounTotal]);
+      if (targetRgb && nounTotal > 0) {
+        nounMatches.push([nounId, matchedTotal / nounTotal]);
+      }
+    }
+
+    const totalHits = Array.from(colorCounts.values()).reduce((sum, value) => sum + value, 0);
+    const sorted = Array.from(colorCounts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, safeLimit)
+      .map(([hex, count]) => ({
+        hex,
+        count,
+        pct: totalHits ? Math.round((count / totalHits) * 1000) / 10 : 0,
+      }));
+
+    let topNouns: string[];
+    let matchPercent: number | null = null;
+
+    if (targetRgb) {
+      const sortedMatches = nounMatches
+        .filter(([, score]) => score > 0)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, safeNounLimit);
+      topNouns = sortedMatches.map(([id]) => id);
+      matchPercent = sortedMatches[0]?.[1] ? Math.round(sortedMatches[0][1] * 1000) / 10 : 0;
+    } else {
+      topNouns = nounTotals
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, safeNounLimit)
+        .map(([id]) => id);
+    }
+
+    return NextResponse.json(
+      {
+        colors: sorted.map((entry) => entry.hex),
+        topColor: sorted[0]?.hex ?? null,
+        topPercent: sorted[0]?.pct ?? null,
+        totalNouns: entries.length,
+        nounIds: topNouns,
+        matchColor,
+        matchPercent,
+        matchTolerance: safeTolerance,
+      },
+      { headers: CACHE_HEADERS }
+    );
+  } catch (error) {
+    return NextResponse.json({ error: "Failed to load Nouns color data" }, { status: 500 });
+  }
+}

--- a/src/app/api/opengraph/route.ts
+++ b/src/app/api/opengraph/route.ts
@@ -86,9 +86,26 @@ export async function GET(request: NextRequest) {
                        getMetaContent("description") || 
                        null;
 
-    const image = getMetaContent("og:image") || 
-                  getMetaContent("twitter:image") || 
-                  null;
+    const normalizeMetadataUrl = (value: string | null, baseUrl: URL): string | null => {
+      if (!value) return null;
+      try {
+        const normalized = new URL(value, baseUrl);
+        if (normalized.protocol === "http:") {
+          normalized.protocol = "https:";
+        }
+        return normalized.protocol === "https:" ? normalized.toString() : null;
+      } catch {
+        return null;
+      }
+    };
+
+    const rawImage =
+      getMetaContent("og:image") ||
+      getMetaContent("twitter:image") ||
+      getMetaContent("twitter:image:src") ||
+      null;
+
+    const image = normalizeMetadataUrl(rawImage, parsedUrl);
 
     const siteName = getMetaContent("og:site_name") || 
                      new URL(url).hostname;

--- a/src/fidgets/farcaster/components/Embeds/GitHubEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/GitHubEmbed.tsx
@@ -1,0 +1,407 @@
+import React, { useEffect, useMemo, useState } from "react";
+import Image from "next/image";
+import OpenGraphEmbed from "./OpenGraphEmbed";
+import { mergeClasses } from "@/common/lib/utils/mergeClasses";
+import { formatTimeAgo } from "@/common/lib/utils/date";
+
+type GitHubLabel = {
+  name: string;
+  color: string;
+};
+
+type GitHubRepo = {
+  owner: string;
+  name: string;
+  fullName: string;
+  url: string;
+  avatarUrl?: string;
+};
+
+type GitHubIssue = {
+  number: number;
+  title: string;
+  state: "open" | "closed";
+  comments: number;
+  updatedAt?: string;
+  author?: {
+    login: string;
+    avatarUrl: string;
+    url: string;
+  } | null;
+  labels?: GitHubLabel[];
+  isMerged?: boolean;
+  isDraft?: boolean;
+};
+
+type GitHubEmbedData = {
+  type: "repo" | "issue" | "pull" | "user";
+  url: string;
+  repo?: GitHubRepo;
+  description?: string;
+  language?: string | null;
+  topics?: string[];
+  license?: string | null;
+  isFork?: boolean;
+  isPrivate?: boolean;
+  isArchived?: boolean;
+  stats?: {
+    stars?: number;
+    forks?: number;
+    issues?: number;
+    watchers?: number;
+  };
+  updatedAt?: string;
+  issue?: GitHubIssue;
+  user?: {
+    login: string;
+    name?: string;
+    bio?: string;
+    avatarUrl?: string;
+    followers?: number;
+    following?: number;
+    publicRepos?: number;
+    company?: string | null;
+    location?: string | null;
+  };
+};
+
+export const isGitHubUrl = (url: string): boolean => {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname === "github.com" || parsed.hostname === "www.github.com";
+  } catch {
+    return false;
+  }
+};
+
+const formatCount = (value?: number) => {
+  if (value === undefined || value === null) return null;
+  if (value < 1000) return `${value}`;
+  if (value < 1000000) {
+    const rounded = Math.round((value / 1000) * 10) / 10;
+    return `${rounded}`.replace(/\.0$/, "") + "k";
+  }
+  const rounded = Math.round((value / 1000000) * 10) / 10;
+  return `${rounded}`.replace(/\.0$/, "") + "m";
+};
+
+const getLabelTextColor = (hex: string) => {
+  const cleaned = hex.replace("#", "");
+  if (cleaned.length !== 6) return "#111827";
+  const r = parseInt(cleaned.slice(0, 2), 16);
+  const g = parseInt(cleaned.slice(2, 4), 16);
+  const b = parseInt(cleaned.slice(4, 6), 16);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b);
+  return luminance > 186 ? "#111827" : "#ffffff";
+};
+
+const languageColor = (language?: string | null) => {
+  if (!language) return "#94a3b8";
+  let hash = 0;
+  for (let i = 0; i < language.length; i += 1) {
+    hash = (hash << 5) - hash + language.charCodeAt(i);
+    hash |= 0;
+  }
+  const hue = Math.abs(hash) % 360;
+  return `hsl(${hue} 65% 45%)`;
+};
+
+const GitHubIcon = ({ className }: { className?: string }) => (
+  <svg
+    className={className}
+    viewBox="0 0 16 16"
+    width="16"
+    height="16"
+    aria-hidden="true"
+  >
+    <path
+      fill="currentColor"
+      d="M8 0C3.58 0 0 3.58 0 8a8 8 0 0 0 5.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.5-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.19 0 .21.15.46.55.38A8 8 0 0 0 16 8c0-4.42-3.58-8-8-8Z"
+    />
+  </svg>
+);
+
+const cardClasses =
+  "relative w-full rounded-xl border border-foreground/15 bg-background/70 p-4 shadow-sm";
+
+const ExternalLinkButton = ({ url, label = "Open" }: { url: string; label?: string }) => (
+  <a
+    href={url}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="absolute right-3 top-3 inline-flex items-center gap-1 rounded-full border border-foreground/15 bg-background/80 px-2 py-1 text-[11px] font-medium text-foreground/70 shadow-sm transition-colors hover:border-foreground/30 hover:text-foreground"
+  >
+    {label}
+    <span aria-hidden="true">↗</span>
+  </a>
+);
+
+const GitHubEmbed: React.FC<{ url: string }> = ({ url }) => {
+  const [data, setData] = useState<GitHubEmbedData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchData = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+        setData(null);
+
+        const response = await fetch(`/api/github?url=${encodeURIComponent(url)}`);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch GitHub data: ${response.statusText}`);
+        }
+
+        const payload = await response.json();
+        if (!cancelled) {
+          setData(payload);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Unknown error");
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchData();
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  const updatedLabel = useMemo(() => {
+    const updatedAt = data?.issue?.updatedAt || data?.updatedAt;
+    if (!updatedAt) return null;
+    return formatTimeAgo(new Date(updatedAt));
+  }, [data?.issue?.updatedAt, data?.updatedAt]);
+
+  if (isLoading) {
+    return (
+      <div className="w-full rounded-xl border border-foreground/15 bg-background/50 p-4">
+        <div className="animate-pulse space-y-3">
+          <div className="h-4 w-1/3 rounded bg-foreground/10" />
+          <div className="h-3 w-2/3 rounded bg-foreground/10" />
+          <div className="h-3 w-1/2 rounded bg-foreground/10" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return <OpenGraphEmbed url={url} />;
+  }
+
+  if (data.type === "user" && data.user) {
+    const name = data.user.name || data.user.login;
+    const metaParts = [data.user.company, data.user.location].filter(Boolean);
+    return (
+      <div className="w-full">
+        <div className={cardClasses}>
+          <ExternalLinkButton url={data.url} label="Open" />
+          <div className="flex items-start gap-3">
+            {data.user.avatarUrl && (
+              <Image
+                src={data.user.avatarUrl}
+                alt={`${data.user.login} avatar`}
+                width={52}
+                height={52}
+                className="rounded-full ring-2 ring-foreground/10"
+              />
+            )}
+            <div className="min-w-0 flex-1 pr-12">
+              <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-foreground/60">
+                <GitHubIcon className="h-3.5 w-3.5" />
+                GitHub Profile
+              </div>
+              <div className="mt-0.5 font-semibold text-foreground truncate">{name}</div>
+              <div className="text-xs text-foreground/60">@{data.user.login}</div>
+              {metaParts.length > 0 && (
+                <div className="mt-1 text-xs text-foreground/60">
+                  {metaParts.join(" • ")}
+                </div>
+              )}
+            </div>
+          </div>
+          {data.user.bio && (
+            <div className="mt-2 text-sm text-foreground/70 line-clamp-2">{data.user.bio}</div>
+          )}
+          <div className="mt-3 flex flex-wrap gap-4 text-xs text-foreground/70">
+            {data.user.publicRepos !== undefined && <span>Repos {formatCount(data.user.publicRepos)}</span>}
+            {data.user.followers !== undefined && <span>Followers {formatCount(data.user.followers)}</span>}
+            {data.user.following !== undefined && <span>Following {formatCount(data.user.following)}</span>}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const repo = data.repo;
+  if (!repo) {
+    return <OpenGraphEmbed url={url} />;
+  }
+
+  const repoTitle = repo.fullName || `${repo.owner}/${repo.name}`;
+  const stats = data.stats || {};
+  const repoBadges = [
+    data.isPrivate ? "Private" : null,
+    data.isArchived ? "Archived" : null,
+    data.isFork ? "Fork" : null,
+  ].filter(Boolean) as string[];
+
+  if (data.type === "repo") {
+    return (
+      <div className="w-full">
+        <div className={cardClasses}>
+          <ExternalLinkButton url={data.url} label="Open" />
+          <div className="flex items-start gap-3">
+            {repo.avatarUrl && (
+              <Image
+                src={repo.avatarUrl}
+                alt={`${repo.owner} avatar`}
+                width={36}
+                height={36}
+                className="rounded-full ring-2 ring-foreground/10"
+              />
+            )}
+            <div className="min-w-0 pr-12">
+              <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-foreground/60">
+                <GitHubIcon className="h-3.5 w-3.5" />
+                GitHub Repository
+              </div>
+              <div className="font-semibold text-foreground truncate">{repoTitle}</div>
+              {repoBadges.length > 0 && (
+                <div className="mt-1 flex flex-wrap gap-1.5">
+                  {repoBadges.map((badge) => (
+                    <span
+                      key={badge}
+                      className="rounded-full border border-foreground/10 px-2 py-0.5 text-[11px] font-medium text-foreground/70"
+                    >
+                      {badge}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+          {data.description && (
+            <div className="mt-2 text-sm text-foreground/70 line-clamp-2">{data.description}</div>
+          )}
+          {data.topics && data.topics.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {data.topics.slice(0, 3).map((topic) => (
+                <span
+                  key={topic}
+                  className="rounded-full bg-foreground/10 px-2 py-0.5 text-[11px] font-medium text-foreground/70"
+                >
+                  {topic}
+                </span>
+              ))}
+            </div>
+          )}
+          <div className="mt-3 flex flex-wrap gap-4 text-xs text-foreground/70">
+            {data.language && (
+              <span className="inline-flex items-center gap-1">
+                <span
+                  className="h-2 w-2 rounded-full"
+                  style={{ backgroundColor: languageColor(data.language) }}
+                />
+                {data.language}
+              </span>
+            )}
+            {data.license && data.license !== "NOASSERTION" && <span>License {data.license}</span>}
+            {stats.stars !== undefined && <span>Stars {formatCount(stats.stars)}</span>}
+            {stats.forks !== undefined && <span>Forks {formatCount(stats.forks)}</span>}
+            {stats.issues !== undefined && <span>Issues {formatCount(stats.issues)}</span>}
+            {stats.watchers !== undefined && <span>Watchers {formatCount(stats.watchers)}</span>}
+            {updatedLabel && <span>Updated {updatedLabel}</span>}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const issue = data.issue;
+  if (!issue) {
+    return <OpenGraphEmbed url={url} />;
+  }
+
+  const stateLabel = issue.isMerged
+    ? "Merged"
+    : issue.state === "open"
+      ? "Open"
+      : "Closed";
+
+  const stateClass = issue.isMerged
+    ? "bg-emerald-500/15 text-emerald-600"
+    : issue.state === "open"
+      ? "bg-blue-500/15 text-blue-600"
+      : "bg-gray-500/15 text-gray-600";
+
+  return (
+    <div className="w-full">
+      <div className={cardClasses}>
+        <ExternalLinkButton url={data.url} label="Open" />
+        <div className="flex flex-wrap items-center gap-2 pr-12 text-xs text-foreground/70">
+          <span className="rounded-full border border-foreground/15 px-2 py-0.5 text-foreground/80">
+            {data.type === "pull" ? "Pull Request" : "Issue"}
+          </span>
+          <span className={mergeClasses("rounded-full px-2 py-0.5", stateClass)}>
+            {stateLabel}
+          </span>
+          {issue.isDraft && (
+            <span className="rounded-full border border-foreground/15 px-2 py-0.5 text-foreground/70">
+              Draft
+            </span>
+          )}
+        </div>
+        <div className="mt-2 flex items-start gap-2">
+          {issue.author?.avatarUrl && (
+            <Image
+              src={issue.author.avatarUrl}
+              alt={`${issue.author.login} avatar`}
+              width={28}
+              height={28}
+              className="rounded-full ring-2 ring-foreground/10"
+            />
+          )}
+          <div className="min-w-0 pr-12">
+            <div className="font-semibold text-foreground line-clamp-2">{issue.title}</div>
+            <div className="mt-0.5 text-xs text-foreground/60">
+              {repoTitle} #{issue.number}
+              {issue.author?.login ? ` by ${issue.author.login}` : ""}
+            </div>
+          </div>
+        </div>
+        {issue.labels && issue.labels.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {issue.labels.slice(0, 3).map((label) => (
+              <span
+                key={label.name}
+                className="rounded-full px-2 py-0.5 text-[11px] font-medium"
+                style={{
+                  backgroundColor: `#${label.color}`,
+                  color: getLabelTextColor(label.color),
+                }}
+              >
+                {label.name}
+              </span>
+            ))}
+          </div>
+        )}
+        <div className="mt-3 flex flex-wrap gap-3 text-xs text-foreground/70">
+          <span>Comments: {issue.comments}</span>
+          {updatedLabel && <span>Updated: {updatedLabel}</span>}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GitHubEmbed;

--- a/src/fidgets/farcaster/components/Embeds/HighlightEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/HighlightEmbed.tsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useState } from "react";
+
+export const isHighlightUrl = (url: string): boolean => {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname === "highlight.xyz" || parsed.hostname === "www.highlight.xyz";
+  } catch {
+    return false;
+  }
+};
+
+type HighlightOgData = {
+  title?: string;
+  description?: string;
+  image?: string;
+  siteName?: string;
+};
+
+const HighlightEmbed: React.FC<{ url: string }> = ({ url }) => {
+  const [ogData, setOgData] = useState<HighlightOgData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadOg = async () => {
+      try {
+        setIsLoading(true);
+        setHasError(false);
+        const response = await fetch(`/api/opengraph?url=${encodeURIComponent(url)}`);
+        if (!response.ok) throw new Error("Failed to fetch OG");
+        const data = (await response.json()) as HighlightOgData;
+        if (!cancelled) {
+          setOgData(data);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setHasError(true);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    loadOg();
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  const title = ogData?.title || "Create and collect NFTs";
+  const description = ogData?.description || "Launch collections, mint, and explore creators.";
+  const image = ogData?.image;
+  const siteLabel = ogData?.siteName || "Highlight";
+  const domainLabel = (() => {
+    try {
+      return new URL(url).hostname;
+    } catch {
+      return "highlight.xyz";
+    }
+  })();
+
+  if (isLoading) {
+    return (
+      <div className="w-full rounded-xl border border-foreground/15 bg-background/50 p-4">
+        <div className="animate-pulse space-y-3">
+          <div className="h-4 w-1/3 rounded bg-foreground/10" />
+          <div className="h-24 w-full rounded-lg bg-foreground/10" />
+          <div className="h-3 w-2/3 rounded bg-foreground/10" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full">
+      <div className="relative w-full overflow-hidden rounded-xl border border-foreground/15 bg-background/70 shadow-sm">
+        <div className="relative w-full bg-black/90">
+          {image ? (
+            <img
+              src={image}
+              alt={title}
+              className="mx-auto max-h-60 w-auto max-w-full object-contain"
+              loading="lazy"
+            />
+          ) : (
+            <div className="h-40 w-full bg-gradient-to-br from-[#0b0b0f] via-[#14161d] to-[#1f2937]" />
+          )}
+          <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-black/0" />
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="absolute right-3 top-3 z-10 inline-flex items-center gap-1 rounded-full border border-white/30 bg-black/60 px-2 py-1 text-[11px] font-medium text-white shadow-sm transition-colors hover:border-white/60"
+          >
+            Open
+            <span aria-hidden="true">↗</span>
+          </a>
+          <div className="absolute left-3 top-3 inline-flex items-center gap-2 rounded-full bg-black/60 px-2 py-1 text-xs font-medium text-white">
+            <span className="inline-flex size-5 items-center justify-center rounded-full bg-white/15 text-[11px]">
+              H
+            </span>
+            {siteLabel}
+          </div>
+          <div className="absolute inset-x-3 bottom-3 text-white">
+            <div className="text-[11px] uppercase tracking-wide text-white/80">{domainLabel}</div>
+            <div className="text-base font-semibold line-clamp-2">{title}</div>
+          </div>
+        </div>
+        <div className="px-4 py-4">
+          <div className="text-sm text-foreground/70 line-clamp-3">{description}</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HighlightEmbed;

--- a/src/fidgets/farcaster/components/Embeds/NounsColorEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/NounsColorEmbed.tsx
@@ -1,0 +1,340 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+
+const NOUNS_BG_SWATCHES = ["#d5d7e1", "#e1d7d5"] as const;
+const DEFAULT_NOUN_LIMIT = 6;
+const DEFAULT_TOLERANCE = 20;
+
+type NounsColorResponse = {
+  colors?: string[];
+  topColor?: string | null;
+  topPercent?: number | null;
+  totalNouns?: number;
+  nounIds?: string[];
+  matchColor?: string | null;
+  matchPercent?: number | null;
+  matchTolerance?: number;
+};
+
+const normalizeHex = (value: string): string | null => {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const raw = trimmed.startsWith("#") ? trimmed.slice(1) : trimmed;
+  if (raw.length === 3 && /^[0-9a-fA-F]{3}$/.test(raw)) {
+    return `#${raw.split("").map((ch) => ch + ch).join("").toLowerCase()}`;
+  }
+  if (/^[0-9a-fA-F]{6}$/.test(raw)) {
+    return `#${raw.toLowerCase()}`;
+  }
+  return null;
+};
+
+export const isNounsColorUrl = (url: string): boolean => {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname === "nounscolor.xctx.io";
+  } catch {
+    return false;
+  }
+};
+
+const NounsColorEmbed: React.FC<{ url: string }> = ({ url }) => {
+  const [colors, setColors] = useState<string[]>([]);
+  const [topColor, setTopColor] = useState<string | null>(null);
+  const [topPercent, setTopPercent] = useState<number | null>(null);
+  const [matchPercent, setMatchPercent] = useState<number | null>(null);
+  const [selectedColor, setSelectedColor] = useState<string>("#d5d7e1");
+  const [colorInput, setColorInput] = useState<string>("#D5D7E1");
+  const [tolerance, setTolerance] = useState(DEFAULT_TOLERANCE);
+  const [hasCustomColor, setHasCustomColor] = useState(false);
+  const [nounIds, setNounIds] = useState<string[]>([]);
+  const [totalNouns, setTotalNouns] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+  const [refreshToken, setRefreshToken] = useState(0);
+  const [copiedColor, setCopiedColor] = useState<string | null>(null);
+
+  const placeholderSwatches = useMemo(() => Array.from({ length: 10 }, (_, idx) => idx), []);
+  const placeholderNouns = useMemo(
+    () => Array.from({ length: DEFAULT_NOUN_LIMIT }, (_, idx) => idx),
+    []
+  );
+
+  const handleRefresh = useCallback(() => {
+    setRefreshToken(Date.now());
+  }, []);
+
+  const handleCopyColor = useCallback(async (color: string) => {
+    try {
+      await navigator.clipboard.writeText(color);
+      setCopiedColor(color);
+    } catch (error) {
+      setCopiedColor(null);
+    }
+  }, []);
+
+  const handleColorInputChange = useCallback((value: string) => {
+    setColorInput(value);
+    const normalized = normalizeHex(value);
+    if (normalized) {
+      setSelectedColor(normalized);
+      setColorInput(normalized.toUpperCase());
+      setHasCustomColor(true);
+    }
+  }, []);
+
+  const handleColorPickerChange = useCallback((value: string) => {
+    const normalized = normalizeHex(value);
+    if (!normalized) return;
+    setSelectedColor(normalized);
+    setColorInput(normalized.toUpperCase());
+    setHasCustomColor(true);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadPalette = async () => {
+      try {
+        setIsLoading(true);
+        setHasError(false);
+        const params = new URLSearchParams({
+          limit: "10",
+          nounLimit: String(DEFAULT_NOUN_LIMIT),
+          ts: String(refreshToken),
+          tolerance: String(tolerance),
+        });
+        if (selectedColor) {
+          params.set("color", selectedColor);
+        }
+        const response = await fetch(`/api/nounscolor?${params.toString()}`, { cache: "no-store" });
+        if (!response.ok) throw new Error("Failed to fetch palette");
+        const data = (await response.json()) as NounsColorResponse;
+        if (cancelled) return;
+        if (Array.isArray(data.colors) && data.colors.length > 0) {
+          setColors(data.colors);
+        }
+        if (data.topColor) {
+          setTopColor(data.topColor);
+          if (!hasCustomColor && normalizeHex(data.topColor)) {
+            const normalized = normalizeHex(data.topColor)!;
+            setSelectedColor(normalized);
+            setColorInput(normalized.toUpperCase());
+          }
+        }
+        if (typeof data.topPercent === "number") {
+          setTopPercent(data.topPercent);
+        }
+        if (typeof data.matchPercent === "number") {
+          setMatchPercent(data.matchPercent);
+        } else {
+          setMatchPercent(null);
+        }
+        if (Array.isArray(data.nounIds) && data.nounIds.length > 0) {
+          setNounIds(data.nounIds);
+        }
+        if (typeof data.totalNouns === "number") {
+          setTotalNouns(data.totalNouns);
+        }
+      } catch (error) {
+        setHasError(true);
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    loadPalette();
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshToken, selectedColor, tolerance, hasCustomColor]);
+
+  useEffect(() => {
+    if (!copiedColor) return;
+    const timeout = window.setTimeout(() => {
+      setCopiedColor(null);
+    }, 1600);
+    return () => window.clearTimeout(timeout);
+  }, [copiedColor]);
+
+  return (
+    <div className="w-full">
+      <div className="w-full overflow-hidden rounded-xl border border-foreground/15 bg-background/70 shadow-sm">
+        <div className="relative bg-gradient-to-r from-[#e1d7d5]/70 via-[#d5d7e1]/60 to-[#f1f5f9] px-4 py-3">
+          <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-foreground/60">
+            <span className="inline-flex size-6 items-center justify-center rounded-md bg-foreground/10 text-foreground/70 font-semibold">
+              N
+            </span>
+            <span>Nouns Color Explorer</span>
+          </div>
+          <div className="absolute right-3 top-3 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleRefresh}
+              className="inline-flex items-center rounded-full border border-foreground/15 bg-background/80 px-2 py-1 text-[11px] font-medium text-foreground/70 shadow-sm transition-colors hover:border-foreground/30 hover:text-foreground"
+            >
+              Refresh
+            </button>
+            <a
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 rounded-full border border-foreground/15 bg-background/80 px-2 py-1 text-[11px] font-medium text-foreground/70 shadow-sm transition-colors hover:border-foreground/30 hover:text-foreground"
+            >
+              Open site
+              <span aria-hidden="true">↗</span>
+            </a>
+          </div>
+          <div className="mt-1 text-base font-semibold text-foreground">
+            Discover Nouns by palette
+          </div>
+          <div className="text-sm text-foreground/70">
+            Match hex colors to Noun traits.
+          </div>
+        </div>
+
+        <div className="px-4 py-3">
+          <div className="flex items-center gap-3">
+            <div className="relative inline-flex h-8 w-8 rounded-lg border border-foreground/10">
+              <span
+                className="h-full w-full rounded-lg"
+                style={{ backgroundColor: selectedColor || "rgba(15, 23, 42, 0.1)" }}
+              />
+              <input
+                type="color"
+                aria-label="Pick color"
+                value={selectedColor}
+                onChange={(event) => handleColorPickerChange(event.target.value)}
+                className="absolute inset-0 cursor-pointer opacity-0"
+              />
+            </div>
+            <input
+              type="text"
+              value={colorInput}
+              onChange={(event) => handleColorInputChange(event.target.value)}
+              onBlur={() => setColorInput(selectedColor.toUpperCase())}
+              className="w-24 rounded-lg border border-foreground/10 bg-background px-2 py-1 text-xs font-semibold uppercase text-foreground"
+              aria-label="Hex color"
+            />
+            <div className="ml-auto rounded-full bg-foreground/10 px-3 py-1 text-xs font-medium text-foreground/70">
+              {matchPercent !== null
+                ? `Match ${matchPercent}%`
+                : topPercent !== null
+                  ? `Top color ${topPercent}%`
+                  : "Top color"}
+            </div>
+          </div>
+          <div className="mt-3 flex items-center gap-3 text-xs text-foreground/60">
+            <span className="font-medium">Tolerance</span>
+            <input
+              type="range"
+              min={0}
+              max={100}
+              value={tolerance}
+              onChange={(event) => setTolerance(Number(event.target.value))}
+              className="h-1 flex-1 cursor-pointer"
+            />
+            <span className="min-w-[36px] text-right">{tolerance}</span>
+          </div>
+          <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-foreground/10">
+            <div
+              className="h-full rounded-full bg-gradient-to-r from-blue-500 to-fuchsia-500 transition-[width] duration-500"
+              style={{
+                width:
+                  matchPercent !== null
+                    ? `${Math.min(matchPercent, 100)}%`
+                    : topPercent
+                      ? `${Math.min(topPercent, 100)}%`
+                      : "60%",
+              }}
+            />
+          </div>
+        </div>
+
+        <div className="px-4 pb-4">
+          <div className="flex flex-wrap gap-2">
+            {colors.length
+              ? colors.map((color) => (
+                  <button
+                    type="button"
+                    key={color}
+                    className="h-5 w-5 rounded-full border border-foreground/10"
+                    style={{ backgroundColor: color }}
+                    aria-label={`Copy ${color}`}
+                    onClick={() => handleCopyColor(color)}
+                  />
+                ))
+              : placeholderSwatches.map((idx) => (
+                  <span
+                    key={idx}
+                    className="h-5 w-5 rounded-full border border-foreground/10 bg-foreground/10"
+                    aria-hidden="true"
+                  />
+            ))}
+          </div>
+
+          <div className="mt-3 flex items-center gap-2 text-xs text-foreground/60">
+            <span className="font-medium">Backgrounds</span>
+            {NOUNS_BG_SWATCHES.map((color) => (
+              <span
+                key={color}
+                className="h-4 w-4 rounded-full border border-foreground/10"
+                style={{ backgroundColor: color }}
+                aria-hidden="true"
+              />
+            ))}
+            {copiedColor && (
+              <span className="ml-auto rounded-full bg-foreground/10 px-2 py-0.5 text-[11px] text-foreground/70">
+                Copied {copiedColor.toUpperCase()}
+              </span>
+            )}
+          </div>
+
+          <div className="mt-4">
+            <div className="flex items-center justify-between text-xs text-foreground/60">
+              <span className="font-medium">Top Nouns</span>
+              {totalNouns ? <span>{totalNouns} total</span> : null}
+            </div>
+            <div className="mt-2 grid grid-cols-3 gap-2 sm:grid-cols-6">
+              {nounIds.length
+                ? nounIds.map((nounId) => (
+                    <a
+                      key={nounId}
+                      href={`https://nouns.wtf/noun/${nounId}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="relative aspect-square overflow-hidden rounded-lg border border-foreground/10 bg-white/80 transition-transform hover:-translate-y-0.5"
+                    >
+                      <img
+                        src={`https://noun.pics/${nounId}.svg`}
+                        alt={`Noun ${nounId}`}
+                        className="h-full w-full object-contain"
+                        loading="lazy"
+                        decoding="async"
+                        style={{ imageRendering: "pixelated" }}
+                      />
+                      <div className="absolute bottom-1 left-1 rounded bg-black/60 px-1 text-[10px] text-white">
+                        #{nounId}
+                      </div>
+                    </a>
+                  ))
+                : placeholderNouns.map((idx) => (
+                    <div
+                      key={idx}
+                      className="aspect-square rounded-lg border border-foreground/10 bg-foreground/10"
+                      aria-hidden="true"
+                    />
+                  ))}
+            </div>
+          </div>
+
+          <div className="mt-3 text-xs text-foreground/50">
+            {isLoading ? "Loading live palette..." : hasError ? "Palette unavailable" : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NounsColorEmbed;

--- a/src/fidgets/farcaster/components/Embeds/SmartFrameEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/SmartFrameEmbed.tsx
@@ -10,9 +10,10 @@ import Loading from "@/common/components/molecules/Loading";
 
 interface SmartFrameEmbedProps {
   url: string;
+  allowOpenGraph?: boolean;
 }
 
-const SmartFrameEmbed: React.FC<SmartFrameEmbedProps> = ({ url }) => {
+const SmartFrameEmbed: React.FC<SmartFrameEmbedProps> = ({ url, allowOpenGraph = true }) => {
   const [isFrameV2, setIsFrameV2] = useState<boolean | null>(null);
   const [isFrameV1, setIsFrameV1] = useState<boolean | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -89,6 +90,9 @@ const SmartFrameEmbed: React.FC<SmartFrameEmbedProps> = ({ url }) => {
 
   // Show loading state with a more neutral placeholder
   if (isLoading) {
+    if (!allowOpenGraph) {
+      return null;
+    }
     return (
       <div className="border border-gray-200 rounded-lg overflow-hidden w-full max-w-2xl">
         <div className="animate-pulse">
@@ -109,6 +113,9 @@ const SmartFrameEmbed: React.FC<SmartFrameEmbedProps> = ({ url }) => {
   }
 
   // If it's neither Frame V1 nor V2, render as OpenGraph metadata card
+  if (!allowOpenGraph) {
+    return null;
+  }
   return <OpenGraphEmbed url={url} />;
 };
 

--- a/src/fidgets/farcaster/components/Embeds/index.tsx
+++ b/src/fidgets/farcaster/components/Embeds/index.tsx
@@ -9,6 +9,9 @@ import VideoEmbed from "./VideoEmbed";
 import ImageEmbed from "./ImageEmbed";
 import SmartFrameEmbed from "./SmartFrameEmbed";
 import ZoraEmbed from "./ZoraEmbed";
+import GitHubEmbed, { isGitHubUrl } from "./GitHubEmbed";
+import NounsColorEmbed, { isNounsColorUrl } from "./NounsColorEmbed";
+import HighlightEmbed, { isHighlightUrl } from "./HighlightEmbed";
 import { isImageUrl, isVideoUrl } from "@/common/lib/utils/urls";
 import CreateCastImage from "./createCastImage";
 
@@ -23,12 +26,14 @@ export type CastEmbed = {
 
 export const renderEmbedForUrl = (
   { url, castId, key }: CastEmbed,
-  isCreateCast: boolean
+  isCreateCast: boolean,
+  options?: { allowOpenGraph?: boolean }
 ) => {
   if (castId) {
     return <EmbededCast castId={castId} key={key} />;
   }
   if (!url) return null;
+  const allowOpenGraph = options?.allowOpenGraph ?? true;
 
   if (isImageUrl(url)) {
     return !isCreateCast ? (
@@ -67,10 +72,16 @@ export const renderEmbedForUrl = (
     return <ParagraphXyzEmbed url={url} key={key} />;
   } else if (url.startsWith("https://open.spotify.com/track")) {
     return <SpotifyEmbed url={url} key={key} />;
+  } else if (isNounsColorUrl(url)) {
+    return <NounsColorEmbed url={url} key={key} />;
+  } else if (isHighlightUrl(url)) {
+    return <HighlightEmbed url={url} key={key} />;
+  } else if (isGitHubUrl(url)) {
+    return <GitHubEmbed url={url} key={key} />;
   } else if (!isImageUrl(url)) {
     // Use smart frame detection to render Frame v2 when possible
     // Falls back to legacy frame system if Frame v2 metadata is not detected
-    return <SmartFrameEmbed url={url} key={key} />;
+    return <SmartFrameEmbed url={url} key={key} allowOpenGraph={allowOpenGraph} />;
   } else {
     return null;
   }


### PR DESCRIPTION
# Embed Updates Summary

## What changed
## Notable files touched
- src/app/api/opengraph/route.ts
- src/app/api/github/route.ts
- src/app/api/nounscolor/route.ts
- src/fidgets/farcaster/components/CastRow.tsx
- src/fidgets/farcaster/components/Embeds/GitHubEmbed.tsx
- src/fidgets/farcaster/components/Embeds/HighlightEmbed.tsx
- src/fidgets/farcaster/components/Embeds/NounsColorEmbed.tsx
- src/fidgets/farcaster/components/Embeds/OpenGraphEmbed.tsx
- src/fidgets/farcaster/components/Embeds/SmartFrameEmbed.tsx
- src/fidgets/farcaster/components/Embeds/index.tsx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added rich previews for GitHub repositories, issues, pull requests, and user profiles displaying repository stats, issue details, and author information.
  * Introduced interactive Nouns color palette explorer with color matching and tolerance controls.
  * Added Highlight.xyz content previews.
  * Improved cast URL handling with deduplication and smart filtering to avoid redundant embeds.
  * Enhanced image handling in link previews for better reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->