### PR TITLE
Restore URL thumbnail previews

### DIFF
--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -272,7 +272,7 @@ const CastEmbedsComponent = ({ cast, onSelectCast }: CastEmbedsProps) => {
               "mt-4 gap-y-4 border border-foreground/15 rounded-xl flex justify-center items-center w-full bg-background/50",
               // only apply clipping for non-twitter embeds
               !isTwitterEmbed ? "overflow-hidden max-h-[500px]" : "",
-              embedData.castId ? "max-w-[100%]" : "max-w-max"
+              embedData.castId ? "max-w-full" : "max-w-full"
             )}
             onClick={(event) => {
               event.stopPropagation();
@@ -317,7 +317,7 @@ const CastEmbedsComponent = ({ cast, onSelectCast }: CastEmbedsProps) => {
             className={classNames(
               "mt-4 gap-y-4 border border-foreground/15 rounded-xl flex justify-center items-center w-full bg-background/50",
               !isTwitterTextUrl ? "overflow-hidden max-h-[500px]" : "",
-              "max-w-max"
+              "max-w-full"
             )}
           >
             {renderedEmbed}

--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -252,6 +252,7 @@ const CastEmbedsComponent = ({ cast, onSelectCast }: CastEmbedsProps) => {
             };
 
         const isTwitterEmbed = isTwitterUrl(isEmbedUrl(embed) ? embed.url : embedData.url);
+        const isVideoEmbed = isEmbedUrl(embed) && isVideoUrl(embed.url);
 
         const shouldAllowOpenGraph =
           !hasPriorityEmbed && !hasRenderedOpenGraph && isEmbedUrl(embed) && !isPriorityUrl(embed.url);
@@ -270,8 +271,11 @@ const CastEmbedsComponent = ({ cast, onSelectCast }: CastEmbedsProps) => {
 
         const wrapperClass = classNames(
           "mt-4 w-full",
-          !isTwitterEmbed && !isFrameEmbed ? "overflow-hidden max-h-[500px]" : "",
-          isFrameEmbed || isOgEmbed ? "" : "gap-y-4 border border-foreground/15 rounded-xl flex justify-center items-center bg-background/50"
+          isFrameEmbed || isOgEmbed || isVideoEmbed ? "max-w-[680px]" : "max-w-full",
+          !isTwitterEmbed && !isFrameEmbed && !isVideoEmbed ? "overflow-hidden max-h-[500px]" : "",
+          isFrameEmbed || isOgEmbed || isVideoEmbed
+            ? ""
+            : "gap-y-4 border border-foreground/15 rounded-xl flex justify-center items-center bg-background/50"
         );
 
         return (
@@ -317,6 +321,7 @@ const CastEmbedsComponent = ({ cast, onSelectCast }: CastEmbedsProps) => {
 
         const wrapperClass = classNames(
           "mt-4 w-full",
+          shouldAllowOpenGraph ? "max-w-[680px]" : "max-w-full",
           !isTwitterTextUrl ? "overflow-hidden max-h-[500px]" : "",
           shouldAllowOpenGraph ? "" : "gap-y-4 border border-foreground/15 rounded-xl flex justify-center items-center bg-background/50"
         );

--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -265,15 +265,19 @@ const CastEmbedsComponent = ({ cast, onSelectCast }: CastEmbedsProps) => {
           return null;
         }
 
+        const isFrameEmbed = isEmbedUrl(embed) && Boolean(embed.metadata?.frame);
+        const isOgEmbed = isEmbedUrl(embed) && shouldAllowOpenGraph && !isFrameEmbed;
+
+        const wrapperClass = classNames(
+          "mt-4 w-full",
+          !isTwitterEmbed && !isFrameEmbed ? "overflow-hidden max-h-[500px]" : "",
+          isFrameEmbed || isOgEmbed ? "" : "gap-y-4 border border-foreground/15 rounded-xl flex justify-center items-center bg-background/50"
+        );
+
         return (
           <div
             key={`embed-${i}`}
-            className={classNames(
-              "mt-4 gap-y-4 border border-foreground/15 rounded-xl flex justify-center items-center w-full bg-background/50",
-              // only apply clipping for non-twitter embeds
-              !isTwitterEmbed ? "overflow-hidden max-h-[500px]" : "",
-              embedData.castId ? "max-w-full" : "max-w-full"
-            )}
+            className={wrapperClass}
             onClick={(event) => {
               event.stopPropagation();
               if (embedData?.castId?.hash) {
@@ -311,15 +315,14 @@ const CastEmbedsComponent = ({ cast, onSelectCast }: CastEmbedsProps) => {
           return null;
         }
 
+        const wrapperClass = classNames(
+          "mt-4 w-full",
+          !isTwitterTextUrl ? "overflow-hidden max-h-[500px]" : "",
+          shouldAllowOpenGraph ? "" : "gap-y-4 border border-foreground/15 rounded-xl flex justify-center items-center bg-background/50"
+        );
+
         return (
-          <div
-            key={`text-url-${i}`}
-            className={classNames(
-              "mt-4 gap-y-4 border border-foreground/15 rounded-xl flex justify-center items-center w-full bg-background/50",
-              !isTwitterTextUrl ? "overflow-hidden max-h-[500px]" : "",
-              "max-w-full"
-            )}
-          >
+          <div key={`text-url-${i}`} className={wrapperClass}>
             {renderedEmbed}
           </div>
         );

--- a/src/fidgets/farcaster/components/Embeds/OpenGraphEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/OpenGraphEmbed.tsx
@@ -86,7 +86,7 @@ const OpenGraphEmbed: React.FC<OpenGraphEmbedProps> = ({ url, metadata }) => {
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className="block w-full max-w-full sm:max-w-[680px]"
+      className="block w-full max-w-full sm:max-w-[400px]"
     >
       <div className="relative aspect-[16/9] w-full overflow-hidden rounded-2xl bg-foreground/10">
         <Image

--- a/src/fidgets/farcaster/components/Embeds/OpenGraphEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/OpenGraphEmbed.tsx
@@ -86,7 +86,7 @@ const OpenGraphEmbed: React.FC<OpenGraphEmbedProps> = ({ url, metadata }) => {
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className="block w-full max-w-full sm:max-w-2xl"
+      className="block w-full max-w-full sm:max-w-[680px]"
     >
       <div className="relative aspect-[16/9] w-full overflow-hidden rounded-2xl bg-foreground/10">
         <Image
@@ -107,7 +107,7 @@ const OpenGraphEmbed: React.FC<OpenGraphEmbedProps> = ({ url, metadata }) => {
       </div>
 
       {domain ? (
-        <div className="mt-2 text-sm text-foreground/60">{domain}</div>
+        <div className="mt-2 text-sm text-foreground/60 pl-3">{domain}</div>
       ) : null}
     </a>
   );

--- a/src/fidgets/farcaster/components/Embeds/OpenGraphEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/OpenGraphEmbed.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import Image from "next/image";
-import { getYouTubeId, isYouTubeUrl } from "@/common/lib/utils/youtubeUtils";
+import { getYouTubeId } from "@/common/lib/utils/youtubeUtils";
 import {
   type EmbedUrlMetadata,
   type OgObject,
@@ -37,8 +37,8 @@ const buildOgDataFromMetadata = (
   const image = pickOgImage(html.ogImage);
 
   return {
-    title: html.ogTitle || html.ogSiteName || html.title,
-    description: html.ogDescription || html.description,
+    title: html.ogTitle || html.ogSiteName,
+    description: html.ogDescription,
     image,
     siteName: html.ogSiteName,
     url: html.ogUrl || url,
@@ -46,62 +46,6 @@ const buildOgDataFromMetadata = (
 };
 
 const OpenGraphEmbed: React.FC<OpenGraphEmbedProps> = ({ url, metadata }) => {
-  const [ogData, setOgData] = useState<OpenGraphData | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (isYouTubeUrl(url)) {
-      setIsLoading(false);
-      return;
-    }
-
-    const fromMetadata = buildOgDataFromMetadata(url, metadata);
-    if (fromMetadata) {
-      setOgData(fromMetadata);
-      setIsLoading(false);
-      setError(null);
-      return;
-    }
-
-    let isMounted = true;
-
-    const fetchOGData = async () => {
-      try {
-        setIsLoading(true);
-        setOgData(null);
-        setError(null);
-
-        const response = await fetch(
-          `/api/opengraph?url=${encodeURIComponent(url)}`
-        );
-
-        if (!response.ok) {
-          throw new Error(`Failed to fetch: ${response.statusText}`);
-        }
-
-        const data = await response.json();
-
-        if (!isMounted) return;
-
-        setOgData(data);
-      } catch (err) {
-        if (!isMounted) return;
-        setError(err instanceof Error ? err.message : "Unknown error");
-      } finally {
-        if (isMounted) {
-          setIsLoading(false);
-        }
-      }
-    };
-
-    fetchOGData();
-
-    return () => {
-      isMounted = false;
-    };
-  }, [metadata, url]);
-
   const youtubeId = getYouTubeId(url);
   if (youtubeId) {
     return (
@@ -117,6 +61,11 @@ const OpenGraphEmbed: React.FC<OpenGraphEmbedProps> = ({ url, metadata }) => {
     );
   }
 
+  const ogData = useMemo(
+    () => buildOgDataFromMetadata(url, metadata),
+    [metadata, url]
+  );
+
   const domain = useMemo(() => {
     try {
       return new URL(ogData?.url || url).hostname.replace(/^www\./, "");
@@ -128,16 +77,7 @@ const OpenGraphEmbed: React.FC<OpenGraphEmbedProps> = ({ url, metadata }) => {
 
   const title = ogData?.title || ogData?.siteName || domain;
 
-  if (isLoading) {
-    return (
-      <div className="w-full max-w-2xl">
-        <div className="relative aspect-video w-full overflow-hidden rounded-2xl bg-foreground/10 animate-pulse" />
-        <div className="mt-2 h-4 w-28 rounded-full bg-foreground/10 animate-pulse" />
-      </div>
-    );
-  }
-
-  if (error || !ogData?.image || !title) {
+  if (!ogData?.image || !title) {
     return null;
   }
 

--- a/src/fidgets/farcaster/components/Embeds/OpenGraphEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/OpenGraphEmbed.tsx
@@ -86,9 +86,9 @@ const OpenGraphEmbed: React.FC<OpenGraphEmbedProps> = ({ url, metadata }) => {
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className="block w-full max-w-2xl"
+      className="block w-full max-w-full sm:max-w-2xl"
     >
-      <div className="relative aspect-video w-full overflow-hidden rounded-2xl bg-foreground/10">
+      <div className="relative aspect-[16/9] w-full overflow-hidden rounded-2xl bg-foreground/10">
         <Image
           src={ogData.image}
           alt={title}

--- a/src/fidgets/farcaster/components/Embeds/SmartFrameEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/SmartFrameEmbed.tsx
@@ -10,9 +10,10 @@ import Loading from "@/common/components/molecules/Loading";
 
 interface SmartFrameEmbedProps {
   url: string;
+  allowOpenGraph?: boolean;
 }
 
-const SmartFrameEmbed: React.FC<SmartFrameEmbedProps> = ({ url }) => {
+const SmartFrameEmbed: React.FC<SmartFrameEmbedProps> = ({ url, allowOpenGraph = true }) => {
   const [isFrameV2, setIsFrameV2] = useState<boolean | null>(null);
   const [isFrameV1, setIsFrameV1] = useState<boolean | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -109,6 +110,10 @@ const SmartFrameEmbed: React.FC<SmartFrameEmbedProps> = ({ url }) => {
   }
 
   // If it's neither Frame V1 nor V2, render as OpenGraph metadata card
+  if (!allowOpenGraph) {
+    return null;
+  }
+
   return <OpenGraphEmbed url={url} />;
 };
 

--- a/src/fidgets/farcaster/components/Embeds/SmartFrameEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/SmartFrameEmbed.tsx
@@ -7,18 +7,37 @@ import {
   isLikelyFrameUrl,
 } from "@/common/lib/utils/frameDetection";
 import Loading from "@/common/components/molecules/Loading";
+import { type EmbedUrlMetadata } from "@neynar/nodejs-sdk/build/api/models";
 
 interface SmartFrameEmbedProps {
   url: string;
   allowOpenGraph?: boolean;
+  metadata?: EmbedUrlMetadata;
 }
 
-const SmartFrameEmbed: React.FC<SmartFrameEmbedProps> = ({ url, allowOpenGraph = true }) => {
+const SmartFrameEmbed: React.FC<SmartFrameEmbedProps> = ({
+  url,
+  allowOpenGraph = true,
+  metadata,
+}) => {
   const [isFrameV2, setIsFrameV2] = useState<boolean | null>(null);
   const [isFrameV1, setIsFrameV1] = useState<boolean | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
+    if (metadata?.frame) {
+      setIsFrameV2(true);
+      setIsFrameV1(false);
+      setIsLoading(false);
+      return;
+    }
+    if (metadata?.html) {
+      setIsFrameV2(false);
+      setIsFrameV1(false);
+      setIsLoading(false);
+      return;
+    }
+
     const abortController = new AbortController();
     let isCancelled = false;
 
@@ -86,7 +105,7 @@ const SmartFrameEmbed: React.FC<SmartFrameEmbedProps> = ({ url, allowOpenGraph =
       isCancelled = true;
       abortController.abort();
     };
-  }, [url]);
+  }, [metadata?.frame, metadata?.html, url]);
 
   // Show loading state with a more neutral placeholder
   if (isLoading) {
@@ -114,7 +133,7 @@ const SmartFrameEmbed: React.FC<SmartFrameEmbedProps> = ({ url, allowOpenGraph =
     return null;
   }
 
-  return <OpenGraphEmbed url={url} />;
+  return <OpenGraphEmbed url={url} metadata={metadata} />;
 };
 
 export default SmartFrameEmbed;

--- a/src/fidgets/farcaster/components/Embeds/index.tsx
+++ b/src/fidgets/farcaster/components/Embeds/index.tsx
@@ -23,7 +23,8 @@ export type CastEmbed = {
 
 export const renderEmbedForUrl = (
   { url, castId, key }: CastEmbed,
-  isCreateCast: boolean
+  isCreateCast: boolean,
+  allowOpenGraph = true
 ) => {
   if (castId) {
     return <EmbededCast castId={castId} key={key} />;
@@ -70,7 +71,7 @@ export const renderEmbedForUrl = (
   } else if (!isImageUrl(url)) {
     // Use smart frame detection to render Frame v2 when possible
     // Falls back to legacy frame system if Frame v2 metadata is not detected
-    return <SmartFrameEmbed url={url} key={key} />;
+    return <SmartFrameEmbed url={url} key={key} allowOpenGraph={allowOpenGraph} />;
   } else {
     return null;
   }

--- a/src/fidgets/farcaster/components/Embeds/index.tsx
+++ b/src/fidgets/farcaster/components/Embeds/index.tsx
@@ -11,6 +11,7 @@ import SmartFrameEmbed from "./SmartFrameEmbed";
 import ZoraEmbed from "./ZoraEmbed";
 import { isImageUrl, isVideoUrl } from "@/common/lib/utils/urls";
 import CreateCastImage from "./createCastImage";
+import { type EmbedUrlMetadata } from "@neynar/nodejs-sdk/build/api/models";
 
 export type CastEmbed = {
   url?: string;
@@ -19,10 +20,11 @@ export type CastEmbed = {
     hash: string | Uint8Array;
   };
   key?: string;
+  metadata?: EmbedUrlMetadata;
 };
 
 export const renderEmbedForUrl = (
-  { url, castId, key }: CastEmbed,
+  { url, castId, key, metadata }: CastEmbed,
   isCreateCast: boolean,
   allowOpenGraph = true
 ) => {
@@ -71,7 +73,14 @@ export const renderEmbedForUrl = (
   } else if (!isImageUrl(url)) {
     // Use smart frame detection to render Frame v2 when possible
     // Falls back to legacy frame system if Frame v2 metadata is not detected
-    return <SmartFrameEmbed url={url} key={key} allowOpenGraph={allowOpenGraph} />;
+    return (
+      <SmartFrameEmbed
+        url={url}
+        key={key}
+        allowOpenGraph={allowOpenGraph}
+        metadata={metadata}
+      />
+    );
   } else {
     return null;
   }


### PR DESCRIPTION
Fulfills #1622. also improves feed performance by utilizing embed data from neynar's existing feed response (rather than detecting/fetching ourselves) and improves ui/ux for casts with multiple images by adding max width and horizontal scrolling carousel.

## Summary
- restore opengraph thumbnail rendering with X-style overlay and remove fallback link emoji buttons
- allow only a single URL preview when a cast has no higher-priority embeds and keep frames/images prioritized
- removes custom logic for detecting mini apps and fetching opengraph data, instead relying on neynar api's feed response which already includes relevant embed data
- implements max width for images, and adds horizontal scrolling carousel for casts with multiple images (similar to farcaster's ux)

## Testing
- view the following embeds in a feed: url (with opengraph data), mini app, image, video

Note: this doesn't handle base app/zora embeds, but #1571 does handle them. will need to merge both and resolve any potential conflicts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952dc1a2a2883258e24dc3824ffb168)