### PR TITLE
Fix public space tab deletion not persisting to database and tab addition not persisting to tabOrder

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -49,7 +49,6 @@ export default function PublicSpace({
     getCurrentSpaceConfig,
     loadSpaceTabOrder,
     updateSpaceTabOrder,
-    commitSpaceTabOrder,
     createSpaceTab,
     deleteSpaceTab,
     renameSpaceTab,
@@ -59,6 +58,7 @@ export default function PublicSpace({
     registerChannelSpace,
     isTabLoading,
     isTabChecked,
+    commitAllSpaceChanges,
   } = useAppStore((state) => ({
     clearLocalSpaces: state.clearLocalSpaces,
     getCurrentSpaceId: state.currentSpace.getCurrentSpaceId,
@@ -79,7 +79,7 @@ export default function PublicSpace({
     commitSpaceTab: state.space.commitSpaceTabToDatabase,
     loadSpaceTabOrder: state.space.loadSpaceTabOrder,
     updateSpaceTabOrder: state.space.updateLocalSpaceOrder,
-    commitSpaceTabOrder: state.space.commitSpaceOrderToDatabase,
+    commitAllSpaceChanges: state.space.commitAllSpaceChanges,
     registerSpaceFid: state.space.registerSpaceFid,
     registerSpaceContract: state.space.registerSpaceContract,
     registerProposalSpace: state.space.registerProposalSpace,
@@ -371,8 +371,8 @@ export default function PublicSpace({
   const commitConfig = useCallback(async () => {
     if (isNil(currentSpaceId) || isNil(currentTabName)) return;
     const network = isTokenSpace(spacePageData) ? spacePageData.tokenData?.network : undefined;
-    commitSpaceTab(currentSpaceId, currentTabName, network);
-  }, [currentSpaceId, currentTabName, spacePageData, commitSpaceTab]);
+    await commitAllSpaceChanges(currentSpaceId, network);
+  }, [currentSpaceId, currentTabName, spacePageData, commitAllSpaceChanges]);
 
   const resetConfig = useCallback(async () => {
     if (isNil(currentSpaceId) || isNil(currentTabName)) return;
@@ -452,14 +452,6 @@ export default function PublicSpace({
               tabName, 
               isTokenSpace(spacePageData) ? spacePageData.tokenData?.network : undefined
             )
-          : undefined;
-      }}
-      commitTabOrder={async () => {
-        return currentSpaceId
-          ? commitSpaceTabOrder(
-            currentSpaceId,
-            isTokenSpace(spacePageData) ? spacePageData.tokenData?.network as EtherScanChainName : undefined,
-          )
           : undefined;
       }}
       getSpacePageUrl={spacePageData.spacePageUrl}

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -23,7 +23,7 @@ interface TabBarProps {
   tabList: string[];
   defaultTab: string;
   updateTabOrder: (newOrder: string[]) => void;
-  commitTabOrder: () => void;
+  commitTabOrder?: () => void;
   deleteTab: (tabName: string) => void;
   createTab: (tabName: string) => Promise<{ tabName: string } | undefined>;
   renameTab: (tabName: string, newName: string) => Promise<void> | void;


### PR DESCRIPTION
## Summary
- `deleteSpaceTab` in `spaceStore.ts` was only staging deletions locally (updating local state and tracking in `deletedTabs`) without ever committing to the database
- Tabs disappeared from the UI but were never actually deleted from Supabase storage, and `tabOrder` was not updated remotely
- Added a call to `commitAllSpaceChanges` after staging, which deletes the tab from storage, updates the tab order, and syncs remote state — matching the pattern used by homebase (private space) tab deletion

## Test plan
- [ ] Delete a tab on a public space and verify it no longer reappears on page refresh
- [ ] Verify the tab order is updated correctly in the database after deletion
- [ ] Confirm homebase (private space) tab deletion still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Tab order persistence now commits immediately (no delayed/debounced updates).
  * Configuration commit workflow upgraded to apply all staged space changes in one operation.

* **Bug Fixes**
  * More robust handling when loading tabs — gracefully falls back to local state on remote failures, reducing lost/missing tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->