### PR TITLE
Portfolio: keep editable defaults and auto-sync address from Farcaster username

### DIFF
--- a/src/common/components/organisms/FidgetSettingsEditor.tsx
+++ b/src/common/components/organisms/FidgetSettingsEditor.tsx
@@ -208,9 +208,19 @@ export const FidgetSettingsEditor: React.FC<FidgetSettingsEditorProps> = ({
   // Subscribe directly to zustand for settings - eliminates prop lag
   const zustandSettings = useFidgetSettings(currentSpaceId, currentTabName, fidgetId);
 
+  const skipDefaults = useMemo(() => {
+    if (properties.fidgetName === "Portfolio") {
+      return ["farcasterUsername", "walletAddresses"];
+    }
+    return undefined;
+  }, [properties.fidgetName]);
+
   const normalizedSettings = useMemo(
-    () => fillWithDefaults(zustandSettings ?? settings, properties.fields),
-    [zustandSettings, settings, properties.fields],
+    () =>
+      fillWithDefaults(zustandSettings ?? settings, properties.fields, {
+        skipDefaults,
+      }),
+    [zustandSettings, settings, properties.fields, skipDefaults],
   );
 
   const [state, setState] = useState<FidgetSettings>(normalizedSettings);
@@ -219,18 +229,22 @@ export const FidgetSettingsEditor: React.FC<FidgetSettingsEditorProps> = ({
   // Update local state when zustand settings change
   useEffect(() => {
     if (zustandSettings) {
-      const normalized = fillWithDefaults(zustandSettings, properties.fields);
+      const normalized = fillWithDefaults(zustandSettings, properties.fields, {
+        skipDefaults,
+      });
       setState(normalized);
     }
-  }, [zustandSettings, properties.fields]);
+  }, [zustandSettings, properties.fields, skipDefaults]);
 
   const saveWithValidation = useCallback(
     (nextState: FidgetSettings, shouldUnselect?: boolean) => {
-      const filledState = fillWithDefaults(nextState, properties.fields);
+      const filledState = fillWithDefaults(nextState, properties.fields, {
+        skipDefaults,
+      });
       setState(filledState);
       onSave(filledState, shouldUnselect);
     },
-    [properties.fields, onSave],
+    [properties.fields, onSave, skipDefaults],
   );
 
   // Save handler for inline field changes (doesn't unselect editor)

--- a/src/common/components/organisms/FidgetSettingsEditor.tsx
+++ b/src/common/components/organisms/FidgetSettingsEditor.tsx
@@ -208,19 +208,9 @@ export const FidgetSettingsEditor: React.FC<FidgetSettingsEditorProps> = ({
   // Subscribe directly to zustand for settings - eliminates prop lag
   const zustandSettings = useFidgetSettings(currentSpaceId, currentTabName, fidgetId);
 
-  const skipDefaults = useMemo(() => {
-    if (properties.fidgetName === "Portfolio") {
-      return ["farcasterUsername", "walletAddresses"];
-    }
-    return undefined;
-  }, [properties.fidgetName]);
-
   const normalizedSettings = useMemo(
-    () =>
-      fillWithDefaults(zustandSettings ?? settings, properties.fields, {
-        skipDefaults,
-      }),
-    [zustandSettings, settings, properties.fields, skipDefaults],
+    () => fillWithDefaults(zustandSettings ?? settings, properties.fields),
+    [zustandSettings, settings, properties.fields],
   );
 
   const [state, setState] = useState<FidgetSettings>(normalizedSettings);
@@ -229,22 +219,18 @@ export const FidgetSettingsEditor: React.FC<FidgetSettingsEditorProps> = ({
   // Update local state when zustand settings change
   useEffect(() => {
     if (zustandSettings) {
-      const normalized = fillWithDefaults(zustandSettings, properties.fields, {
-        skipDefaults,
-      });
+      const normalized = fillWithDefaults(zustandSettings, properties.fields);
       setState(normalized);
     }
-  }, [zustandSettings, properties.fields, skipDefaults]);
+  }, [zustandSettings, properties.fields]);
 
   const saveWithValidation = useCallback(
     (nextState: FidgetSettings, shouldUnselect?: boolean) => {
-      const filledState = fillWithDefaults(nextState, properties.fields, {
-        skipDefaults,
-      });
+      const filledState = fillWithDefaults(nextState, properties.fields);
       setState(filledState);
       onSave(filledState, shouldUnselect);
     },
-    [properties.fields, onSave, skipDefaults],
+    [properties.fields, onSave],
   );
 
   // Save handler for inline field changes (doesn't unselect editor)

--- a/src/fidgets/token/Portfolio.tsx
+++ b/src/fidgets/token/Portfolio.tsx
@@ -13,6 +13,7 @@ import useCurrentFid from "@/common/lib/hooks/useCurrentFid";
 import { useLoadFarcasterUser } from "@/common/data/queries/farcaster";
 import { useNeynarUser } from "@/common/lib/hooks/useNeynarUser";
 import { useFarcasterSigner } from "@/fidgets/farcaster";
+import { useAppStore } from "@/common/data/stores/app";
 import PortfolioUsernameInput, {
   getPortfolioPrimaryAddress,
 } from "./PortfolioUsernameInput";
@@ -108,9 +109,14 @@ const Portfolio: React.FC<FidgetArgs<PortfolioFidgetSettings>> = ({
   const currentFid = useCurrentFid();
   const farcasterSigner = useFarcasterSigner("portfolio");
   const effectiveFid = (currentFid ?? farcasterSigner.fid) ?? -1;
+  const associatedFid = useAppStore(
+    (state) => state.account.getCurrentIdentity()?.associatedFids?.[0],
+  );
+  const lookupFid =
+    effectiveFid > 0 ? effectiveFid : associatedFid ?? -1;
   const { data: currentUserData } = useLoadFarcasterUser(
-    effectiveFid,
-    effectiveFid > 0 ? effectiveFid : undefined,
+    lookupFid,
+    lookupFid > 0 ? lookupFid : undefined,
   );
   const loggedInUsername = useMemo(() => {
     const username = currentUserData?.users?.[0]?.username;
@@ -134,8 +140,8 @@ const Portfolio: React.FC<FidgetArgs<PortfolioFidgetSettings>> = ({
 
   const resolvedFarcasterUsername = useMemo(() => {
     const normalized = (farcasterUsername || "").trim().replace(/^@/, "");
-    return normalized;
-  }, [farcasterUsername]);
+    return normalized || loggedInUsername || "";
+  }, [farcasterUsername, loggedInUsername]);
 
   const resolvedWalletAddresses = useMemo(() => {
     const normalized = (walletAddresses || "").trim();

--- a/src/fidgets/token/PortfolioUsernameInput.tsx
+++ b/src/fidgets/token/PortfolioUsernameInput.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useMemo, useRef } from "react";
+import TextInput from "@/common/components/molecules/TextInput";
+import { useNeynarUser } from "@/common/lib/hooks/useNeynarUser";
+
+type PortfolioInputProps = {
+  id?: string;
+  value: string;
+  onChange?: (value: string) => void;
+  updateSettings?: (partial: Record<string, unknown>) => void;
+  className?: string;
+};
+
+const getPrimaryAddress = (user?: {
+  verifications?: string[];
+  verified_addresses?: { eth_addresses?: string[] };
+  custody_address?: string;
+} | null) => {
+  const verifications = (user?.verifications || [])
+    .map((addr) => (typeof addr === "string" ? addr.trim() : ""))
+    .filter(Boolean);
+  if (verifications.length > 0) return verifications[0]!;
+
+  const verified = (user?.verified_addresses?.eth_addresses || [])
+    .map((addr) => (typeof addr === "string" ? addr.trim() : ""))
+    .filter(Boolean);
+  if (verified.length > 0) return verified[0]!;
+
+  const custody = user?.custody_address;
+  return typeof custody === "string" ? custody.trim() : "";
+};
+
+const PortfolioUsernameInput: React.FC<PortfolioInputProps> = ({
+  value,
+  onChange,
+  updateSettings,
+  ...rest
+}) => {
+  const normalized = (value || "").trim().replace(/^@/, "");
+  const { user } = useNeynarUser(normalized ? normalized : undefined);
+  const primaryAddress = useMemo(() => getPrimaryAddress(user), [user]);
+  const lastAppliedRef = useRef<string>("");
+
+  useEffect(() => {
+    if (!normalized || !primaryAddress || !updateSettings) return;
+    if (lastAppliedRef.current === primaryAddress) return;
+    lastAppliedRef.current = primaryAddress;
+    updateSettings({
+      farcasterUsername: normalized,
+      walletAddresses: primaryAddress,
+    });
+  }, [normalized, primaryAddress, updateSettings]);
+
+  return (
+    <TextInput
+      {...rest}
+      value={value}
+      onChange={(next) => {
+        onChange?.(next);
+      }}
+    />
+  );
+};
+
+export const getPortfolioPrimaryAddress = getPrimaryAddress;
+export default PortfolioUsernameInput;


### PR DESCRIPTION
## Summary
This PR improves the Portfolio fidget so it can:
- Pre-fill from the logged-in Farcaster account when fields are empty
- Respect explicit values (including `nounspacetom`) without being overwritten
- Auto-sync the wallet address when a Farcaster username is entered

## Details
- Extracted `PortfolioUsernameInput` to encapsulate username -> address lookup
- Prevented defaults from being re-applied when users clear fields in the editor
- Added a fallback to use the Farcaster signer FID when `useCurrentFid()` is not available

## UX behavior
- Empty fields → auto-fill from logged-in user
- Custom username → auto-fill address for that user
- Manual address edits → value is kept

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New portfolio username input with auto-detection of primary wallet address.
  * Auto-population of username and wallet fields based on resolved user identity.
  * Persisted "last fetched" settings to retain recent username/address choices.

* **Improvements**
  * Configurable backfill behavior to avoid unwanted overwrites.
  * Safer handling of defaults to prevent replacing intentional values.
  * Reduced unnecessary saves and more reliable data restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->