### PR TITLE
Add hover scale effect to navigation logo

### DIFF
--- a/src/common/components/molecules/BrandHeader.tsx
+++ b/src/common/components/molecules/BrandHeader.tsx
@@ -26,7 +26,7 @@ const BrandHeader = ({ systemConfig }: BrandHeaderProps) => {
   const isSvg = logoSrc?.toLowerCase().endsWith('.svg');
 
   const logoImage = (
-    <div className="w-12 h-8 sm:w-16 sm:h-10 me-3 flex items-center justify-center">
+    <div className="w-12 h-8 sm:w-16 sm:h-10 me-3 flex items-center justify-center transition-transform duration-200 hover:scale-110">
       {isSvg ? (
         // Use regular img tag for SVGs to avoid Next.js Image optimization issues
         // SVGs are rendered in an img tag context which prevents script execution


### PR DESCRIPTION
## Summary

Adds a subtle scale animation to the navigation logo on hover, providing visual feedback that it's a clickable element.

## Changes

- Added `transition-transform duration-200 hover:scale-110` to the logo container in `BrandHeader.tsx`

## Result

- Logo smoothly scales to 110% on hover
- 200ms transition for a polished feel
- Works on both desktop sidebar and mobile header

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added a smooth hover animation to the BrandHeader logo, featuring a subtle scale effect when users interact with it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->