### PR TITLE
Use square mask for custom icons in navigation

### DIFF
--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -352,10 +352,10 @@ const Navigation = React.memo(
   // Reusable component factory for URL icons
   const createUrlIconWrapper = useCallback((src: string): React.FC => {
     const CustomIconWrapper = React.memo(() => (
-      <img 
-        src={src} 
-        alt="icon" 
-        className="w-5 h-5 rounded object-contain" 
+      <img
+        src={src}
+        alt="icon"
+        className="w-5 h-5 object-contain"
         aria-hidden="true"
       />
     ));


### PR DESCRIPTION
## Summary

Changes custom URL icons in the navigation sidebar to display as squares instead of with rounded corners.

## Changes

Removed the `rounded` class from the custom icon wrapper in `Navigation.tsx`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)