### PR TITLE
Add /discord route that opens invite and redirects home

### DIFF
--- a/src/app/discord/page.tsx
+++ b/src/app/discord/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useSystemConfig } from "@/common/providers/SystemConfigProvider";
+
+export default function DiscordRedirect() {
+  const router = useRouter();
+  const systemConfig = useSystemConfig();
+  const discordUrl = systemConfig?.community?.urls?.discord;
+
+  useEffect(() => {
+    if (discordUrl) {
+      // Open Discord invite in new tab
+      window.open(discordUrl, "_blank", "noopener,noreferrer");
+    }
+    // Redirect to home
+    router.replace("/home");
+  }, [discordUrl, router]);
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <p>Redirecting to Discord...</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Creates a `/discord` path that opens the community's Discord invite in a new tab and redirects the user to `/home`.

This allows sharing simple invite links like `spacesystem.blank.space/discord`.

## How it works

1. Page loads and gets Discord URL from system config
2. Opens Discord invite URL in a new tab
3. Redirects user to /home

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)