### PR TITLE
Fix Directory fidget re-querying follow status on settings changes

### DIFF
--- a/src/fidgets/token/Directory/Directory.tsx
+++ b/src/fidgets/token/Directory/Directory.tsx
@@ -183,16 +183,30 @@ const Directory: React.FC<
     }
 
     setDirectoryData((prev) => {
+      // Strip viewerContext for comparison since it's not persisted
+      const stripContext = (members: DirectoryMemberData[] | undefined): DirectoryMemberData[] =>
+        (members ?? []).map(({ viewerContext: _viewerContext, ...rest }) => rest as DirectoryMemberData);
+
+      const prevMembersStripped = stripContext(prev.members);
+      const dataMembersStripped = stripContext(data.members);
+      const membersUnchanged = isEqual(prevMembersStripped, dataMembersStripped);
+
+      // If members haven't changed (ignoring viewerContext), keep prev.members to preserve viewerContext
+      const nextMembers = membersUnchanged
+        ? prev.members
+        : (data.members ?? prev.members);
+
       const next: DirectoryFidgetData = {
-        members: data.members ?? prev.members,
+        members: nextMembers,
         lastUpdatedTimestamp: data.lastUpdatedTimestamp ?? prev.lastUpdatedTimestamp ?? null,
         tokenSymbol: data.tokenSymbol ?? prev.tokenSymbol ?? null,
         tokenDecimals: data.tokenDecimals ?? prev.tokenDecimals ?? null,
         lastFetchSettings: data.lastFetchSettings ?? prev.lastFetchSettings,
       };
 
+      // Check if anything actually changed
       if (
-        isEqual(prev.members, next.members) &&
+        next.members === prev.members &&
         prev.lastUpdatedTimestamp === next.lastUpdatedTimestamp &&
         prev.tokenSymbol === next.tokenSymbol &&
         prev.tokenDecimals === next.tokenDecimals &&


### PR DESCRIPTION
## Summary
- Fixed issue where changing follow button color (or any other setting) in the Directory fidget would cause follow status to be re-fetched from the API
- The root cause was that `viewerContext` is stripped before persisting to storage, so when settings changed and the sync effect ran, it would overwrite the in-memory `viewerContext` with the persisted data (missing viewerContext), triggering the hydration effect

## Changes
- Modified the data sync effect to compare members without `viewerContext` 
- If the underlying member data hasn't changed, we preserve the existing `members` array (with its `viewerContext` intact)
- Only when actual member data changes do we update from the persisted data

## Test plan
- [ ] Open a Directory fidget on a token or channel page
- [ ] Wait for follow status to load on member buttons
- [ ] Open fidget settings and change the follow button color
- [ ] Verify follow buttons update color without network requests to re-fetch follow status
- [ ] Check browser network tab to confirm no calls to `/api/farcaster/neynar/users` when changing button color

🤖 Generated with [Claude Code](https://claude.com/claude-code)