### PR TITLE
Fix discord page build error

### DIFF
--- a/src/app/discord/DiscordRedirect.tsx
+++ b/src/app/discord/DiscordRedirect.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+type DiscordRedirectProps = {
+  discordUrl: string | undefined;
+};
+
+export default function DiscordRedirect({ discordUrl }: DiscordRedirectProps) {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (discordUrl) {
+      // Open Discord invite in new tab
+      window.open(discordUrl, "_blank", "noopener,noreferrer");
+    }
+    // Redirect to home
+    router.replace("/home");
+  }, [discordUrl, router]);
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <p>Redirecting to Discord...</p>
+    </div>
+  );
+}

--- a/src/app/discord/page.tsx
+++ b/src/app/discord/page.tsx
@@ -1,26 +1,13 @@
-"use client";
+import React from "react";
+import { loadSystemConfig } from "@/config";
+import DiscordRedirect from "./DiscordRedirect";
 
-import React, { useEffect } from "react";
-import { useRouter } from "next/navigation";
-import { useSystemConfig } from "@/common/providers/SystemConfigProvider";
+// Force dynamic rendering - config loading requires request context
+export const dynamic = "force-dynamic";
 
-export default function DiscordRedirect() {
-  const router = useRouter();
-  const systemConfig = useSystemConfig();
-  const discordUrl = systemConfig?.community?.urls?.discord;
+export default async function DiscordPage() {
+  const config = await loadSystemConfig();
+  const discordUrl = config?.community?.urls?.discord;
 
-  useEffect(() => {
-    if (discordUrl) {
-      // Open Discord invite in new tab
-      window.open(discordUrl, "_blank", "noopener,noreferrer");
-    }
-    // Redirect to home
-    router.replace("/home");
-  }, [discordUrl, router]);
-
-  return (
-    <div className="flex items-center justify-center min-h-screen">
-      <p>Redirecting to Discord...</p>
-    </div>
-  );
+  return <DiscordRedirect discordUrl={discordUrl} />;
 }


### PR DESCRIPTION
## Summary
Fixes build error: `Module not found: Can't resolve '@/common/providers/SystemConfigProvider'`

## Changes
- Split discord page into server + client components
- Server component (`page.tsx`) loads config using `loadSystemConfig()`
- Client component (`DiscordRedirect.tsx`) handles `window.open` and router navigation

## Test plan
- [ ] Build succeeds: `yarn build`
- [ ] Visit `/discord` route - should open discord in new tab and redirect to home

🤖 Generated with [Claude Code](https://claude.com/claude-code)